### PR TITLE
Changed flashing order

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -265,7 +265,7 @@ $(FW_FILE_1) $(FW_FILE_2): $(PROGRAM_OUT) $(FW_BASE)
 	$(ESPTOOL) elf2image $< -o $(FW_BASE)
 
 flash: $(FW_FILE_1) $(FW_FILE_2)
-	$(ESPTOOL) -p $(ESPPORT) --baud $(ESPBAUD) write_flash $(FW_1) $(FW_FILE_1) $(FW_2) $(FW_FILE_2)
+	$(ESPTOOL) -p $(ESPPORT) --baud $(ESPBAUD) write_flash $(FW_2) $(FW_FILE_2) $(FW_1) $(FW_FILE_1)
 
 size: $(PROGRAM_OUT)
 	$(Q) $(CROSS)size --format=sysv $(PROGRAM_OUT)


### PR DESCRIPTION
Before switching to esp-open-rtos I spent a great deal of time scratching my head until I found out about the ESP ROM SPI flash erase bug when my program failed to boot. As the esptool fix has not been pulled yet, the flashing order needs to change.
