### PR TITLE
Add more *_regs.h definitions

### DIFF
--- a/core/include/esp/dport_regs.h
+++ b/core/include/esp/dport_regs.h
@@ -21,17 +21,46 @@
 */
 
 struct DPORT_REGS {
-    uint32_t volatile _unknown0;    // 0x00
-    uint32_t volatile INT_ENABLE;   // 0x04
+    uint32_t volatile DPORT0;              // 0x00  FIXME: need a better name for this
+    uint32_t volatile INT_ENABLE;          // 0x04
+    uint32_t volatile _unknown08;          // 0x08
+    uint32_t volatile SPI_READY;           // 0x0c
+    uint32_t volatile _unknown10;          // 0x10
+    uint32_t volatile CPU_CLOCK;           // 0x14
+    uint32_t volatile CLOCKGATE_WATCHDOG;  // 0x18
+    uint32_t volatile _unknown1c;          // 0x1c
+    uint32_t volatile SPI_INT_STATUS;      // 0x20
+    uint32_t volatile SPI_CACHE_RAM;       // 0x24
+    uint32_t volatile PERI_IO;             // 0x28
+    uint32_t volatile SLC_TX_DESC_DEBUG;   // 0x2c
+    uint32_t volatile _unknown30;          // 0x30
+    uint32_t volatile _unknown34;          // 0x34
+    uint32_t volatile _unknown38;          // 0x38
+    uint32_t volatile _unknown3c;          // 0x3c
+    uint32_t volatile _unknown40;          // 0x40
+    uint32_t volatile _unknown44;          // 0x44
+    uint32_t volatile _unknown48;          // 0x48
+    uint32_t volatile _unknown4c;          // 0x4c
+    uint32_t volatile OTP_MAC0;            // 0x50
+    uint32_t volatile OTP_MAC1;            // 0x54
+    uint32_t volatile OTP_CHIPID;          // 0x58
+    uint32_t volatile OTP_MAC2;            // 0x5c
 } __attribute__ (( packed ));
 
-_Static_assert(sizeof(struct DPORT_REGS) == 0x08, "DPORT_REGS is the wrong size");
+_Static_assert(sizeof(struct DPORT_REGS) == 0x5c, "DPORT_REGS is the wrong size");
+
+/* Details for DPORT0 register */
+
+/* Currently very little known about this register.  The following is based on analysis of the startup code in the Espressif SDK: */
+
+#define DPORT_DPORT0_FIELD0_M  0x0000007f
+#define DPORT_DPORT0_FIELD0_S  0
 
 /* Details for INT_ENABLE register */
 
 /* Set flags to enable CPU interrupts from some peripherals. Read/write.
 
-   bit 0 - Is set by RTOS SDK startup code but function is unknown.
+   bit 0 - INT_ENABLE_WDT (unclear exactly how this works.  Set by RTOS SDK startup code)
    bit 1 - INT_ENABLE_TIMER0 allows TIMER 0 (FRC1) to trigger interrupt INUM_TIMER_FRC1.
    bit 2 - INT_ENABLE_TIMER1 allows TIMER 1 (FRC2) to trigger interrupt INUM_TIMER_FRC2.
 
@@ -42,6 +71,7 @@ _Static_assert(sizeof(struct DPORT_REGS) == 0x08, "DPORT_REGS is the wrong size"
    - this is unknown.
 */
 
+#define DPORT_INT_ENABLE_WDT     BIT(0)
 #define DPORT_INT_ENABLE_TIMER0  BIT(1)
 #define DPORT_INT_ENABLE_TIMER1  BIT(2)
 
@@ -49,5 +79,47 @@ _Static_assert(sizeof(struct DPORT_REGS) == 0x08, "DPORT_REGS is the wrong size"
  * (FRC2).. */
 #define DPORT_INT_ENABLE_FRC1  DPORT_INT_ENABLE_TIMER0
 #define DPORT_INT_ENABLE_FRC2  DPORT_INT_ENABLE_TIMER1
+
+/* Details for SPI_READY register */
+
+#define DPORT_SPI_READY_IDLE     BIT(9)
+
+/* Details for CPU_CLOCK register */
+
+#define DPORT_CPU_CLOCK_X2       BIT(0)
+
+/* Details for CLOCKGATE_WATCHDOG register */
+
+/* Comment found in pvvx/mp3_decode headers: "use clockgate_watchdog(flg) { if(flg) 0x3FF00018 &= 0x77; else 0x3FF00018 |= 8; }".  Not sure what this means or does. */
+
+#define DPORT_CLOCKGATE_WATCHDOG_DISABLE  BIT(3)
+
+/* Details for SPI_INT_STATUS register */
+
+#define DPORT_SPI_INT_STATUS_SPI0  BIT(4)
+#define DPORT_SPI_INT_STATUS_SPI1  BIT(7)
+#define DPORT_SPI_INT_STATUS_I2S   BIT(9)
+
+/* Details for SPI_CACHE_RAM register */
+
+#define DPORT_SPI_CACHE_RAM_BANK1  BIT(3)
+#define DPORT_SPI_CACHE_RAM_BANK0  BIT(4)
+
+/* Details for PERI_IO register */
+
+#define DPORT_PERI_IO_SWAP_UARTS       BIT(0)
+#define DPORT_PERI_IO_SWAP_SPIS        BIT(1)
+#define DPORT_PERI_IO_SWAP_UART0_PINS  BIT(2)
+#define DPORT_PERI_IO_SWAP_UART1_PINS  BIT(3)
+#define DPORT_PERI_IO_SPI1_PRIORITY    BIT(5)
+#define DPORT_PERI_IO_SPI1_SHARED      BIT(6)
+#define DPORT_PERI_IO_SPI0_SHARED      BIT(7)
+
+/* Details for SLC_TX_DESC_DEBUG register */
+
+#define SLC_TX_DESC_DEBUG_VALUE_M      0x0000ffff
+#define SLC_TX_DESC_DEBUG_VALUE_S      0
+
+#define SLC_TX_DESC_DEBUG_VALUE_MAGIC  0xcccc
 
 #endif /* _ESP_DPORT_REGS_H */

--- a/core/include/esp/dport_regs.h
+++ b/core/include/esp/dport_regs.h
@@ -47,7 +47,7 @@ struct DPORT_REGS {
     uint32_t volatile OTP_MAC2;            // 0x5c
 } __attribute__ (( packed ));
 
-_Static_assert(sizeof(struct DPORT_REGS) == 0x5c, "DPORT_REGS is the wrong size");
+_Static_assert(sizeof(struct DPORT_REGS) == 0x60, "DPORT_REGS is the wrong size");
 
 /* Details for DPORT0 register */
 

--- a/core/include/esp/registers.h
+++ b/core/include/esp/registers.h
@@ -16,6 +16,8 @@
 #include "common_macros.h"
 #include "esp/types.h"
 
+#include "esp/uart_regs.h"
+#include "esp/spi_regs.h"
 #include "esp/iomux_regs.h"
 #include "esp/gpio_regs.h"
 #include "esp/timer_regs.h"
@@ -29,16 +31,16 @@
 #define MMIO_BASE   0x60000000
 //#define DPORT_BASE  0x3ff00000
 
-#define UART0_BASE (MMIO_BASE + 0)
-#define SPI1_BASE  (MMIO_BASE + 0x0100)
-#define SPI_BASE   (MMIO_BASE + 0x0200)
+//#define UART0_BASE (MMIO_BASE + 0)
+//#define SPI1_BASE  (MMIO_BASE + 0x0100)
+//#define SPI_BASE   (MMIO_BASE + 0x0200)
 //#define GPIO0_BASE (MMIO_BASE + 0x0300)
 //#define TIMER_BASE (MMIO_BASE + 0x0600)
 #define RTC_BASE   (MMIO_BASE + 0x0700)
 //#define IOMUX_BASE (MMIO_BASE + 0x0800)
 //#define WDT_BASE   (MMIO_BASE + 0x0900)
 #define I2C_BASE   (MMIO_BASE + 0x0d00)
-#define UART1_BASE (MMIO_BASE + 0x0F00)
+//#define UART1_BASE (MMIO_BASE + 0x0F00)
 #define RTCB_BASE  (MMIO_BASE + 0x1000)
 #define RTCS_BASE  (MMIO_BASE + 0x1100)
 #define RTCU_BASE  (MMIO_BASE + 0x1200)

--- a/core/include/esp/registers.h
+++ b/core/include/esp/registers.h
@@ -22,6 +22,7 @@
 #include "esp/gpio_regs.h"
 #include "esp/timer_regs.h"
 #include "esp/wdt_regs.h"
+#include "esp/rtcmem_regs.h"
 #include "esp/dport_regs.h"
 
 /* Register base addresses
@@ -41,8 +42,8 @@
 //#define WDT_BASE   (MMIO_BASE + 0x0900)
 #define I2C_BASE   (MMIO_BASE + 0x0d00)
 //#define UART1_BASE (MMIO_BASE + 0x0F00)
-#define RTCB_BASE  (MMIO_BASE + 0x1000)
-#define RTCS_BASE  (MMIO_BASE + 0x1100)
-#define RTCU_BASE  (MMIO_BASE + 0x1200)
+//#define RTCB_BASE  (MMIO_BASE + 0x1000)
+//#define RTCS_BASE  (MMIO_BASE + 0x1100)
+//#define RTCU_BASE  (MMIO_BASE + 0x1200)
 
 #endif

--- a/core/include/esp/rtcmem_regs.h
+++ b/core/include/esp/rtcmem_regs.h
@@ -1,0 +1,44 @@
+/* esp/rtcmem_regs.h
+ *
+ * ESP8266 RTC semi-persistent memory register definitions
+ *
+ * Not compatible with ESP SDK register access code.
+ */
+
+#ifndef _ESP_RTCMEM_REGS_H
+#define _ESP_RTCMEM_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+/* The RTC memory is a range of 256 words (1 KB) of general-purpose memory
+ * within the Real Time Clock peripheral.  Because it's part of the RTC, it
+ * continues to be powered (and retains its contents) even when the ESP8266 is
+ * in its deepest sleep mode (and other RAM is lost).  It can therefore be
+ * useful for keeping data which must be persisted through sleep or a reset.
+ *
+ * Note, however, that it is not "battery backed", or flash memory, and thus
+ * will not keep its contents if power is removed entirely.
+ */
+
+// We could just define these as 'volatile uint32_t *', but doing things this
+// way means that the RTCMEM* defines will include array size information, so
+// the C compiler can do bounds-checking for static arguments.
+
+typedef volatile uint32_t rtcmem_array64_t[64];
+typedef volatile uint32_t rtcmem_array128_t[128];
+typedef volatile uint32_t rtcmem_array256_t[256];
+
+#define RTCMEM_BASE 0x60001000
+
+/* RTCMEM is an array covering the entire semi-persistent memory range */
+#define RTCMEM (*(rtcmem_array256_t *)(RTCMEM_BASE))
+
+/* RTCMEM_BACKUP / RTCMEM_SYSTEM / RTCMEM_USER are the same range, divided up
+ * into chunks by application/use, as defined by Espressif */
+
+#define RTCMEM_BACKUP (*(rtcmem_array64_t *)(RTCMEM_BASE))
+#define RTCMEM_SYSTEM (*(rtcmem_array64_t *)(RTCMEM_BASE + 0x100))
+#define RTCMEM_USER (*(rtcmem_array128_t *)(RTCMEM_BASE + 0x200))
+
+#endif /* _ESP_RTCMEM_REGS_H */

--- a/core/include/esp/spi_regs.h
+++ b/core/include/esp/spi_regs.h
@@ -1,0 +1,244 @@
+/** esp/spi.h
+ *
+ * Configuration of SPI registers.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _SPI_REGS_H
+#define _SPI_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+/* Register definitions for the SPI peripherals on the ESP8266.
+ *
+ * There are twp SPI devices built into the ESP8266:
+ *   SPI(0) is at 0x60000200
+ *   SPI(1) is at 0x60000100
+ * (note that the device number order is reversed in memory)
+ *
+ * Each device is allocated a block of 64 32-bit registers (256 bytes of
+ * address space) to communicate with application code.
+ */
+
+#define SPI_BASE 0x60000200
+#define SPI(i) (*(struct SPI_REGS *)(0x60000200 - (i)*0x100))
+
+#define SPI0_BASE SPI_BASE
+#define SPI1_BASE (SPI_BASE - 0x100)
+
+struct SPI_REGS {
+    uint32_t volatile CMD;          // 0x00
+    uint32_t volatile ADDR;         // 0x04
+    uint32_t volatile CTRL0;        // 0x08
+    uint32_t volatile CTRL1;        // 0x0c
+    uint32_t volatile RSTATUS;      // 0x10
+    uint32_t volatile CTRL2;        // 0x14
+    uint32_t volatile CLOCK;        // 0x18
+    uint32_t volatile USER0;        // 0x1c
+    uint32_t volatile USER1;        // 0x20
+    uint32_t volatile USER2;        // 0x24
+    uint32_t volatile WSTATUS;      // 0x28
+    uint32_t volatile PIN;          // 0x2c
+    uint32_t volatile SLAVE0;       // 0x30
+    uint32_t volatile SLAVE1;       // 0x34
+    uint32_t volatile SLAVE2;       // 0x38
+    uint32_t volatile SLAVE3;       // 0x3c
+    uint32_t volatile W0;           // 0x40
+    uint32_t volatile W1;           // 0x44
+    uint32_t volatile W2;           // 0x48
+    uint32_t volatile W3;           // 0x4c
+    uint32_t volatile W4;           // 0x50
+    uint32_t volatile W5;           // 0x54
+    uint32_t volatile W6;           // 0x58
+    uint32_t volatile W7;           // 0x5c
+    uint32_t volatile W8;           // 0x60
+    uint32_t volatile W9;           // 0x64
+    uint32_t volatile W10;          // 0x68
+    uint32_t volatile W11;          // 0x6c
+    uint32_t volatile W12;          // 0x70
+    uint32_t volatile W13;          // 0x74
+    uint32_t volatile W14;          // 0x78
+    uint32_t volatile W15;          // 0x7c
+    uint32_t volatile _unused[28];  // 0x80 - 0xec
+    uint32_t volatile EXT0;         // 0xf0
+    uint32_t volatile EXT1;         // 0xf4
+    uint32_t volatile EXT2;         // 0xf8
+    uint32_t volatile EXT3;         // 0xfc
+} __attribute__ (( packed ));
+
+_Static_assert(sizeof(struct SPI_REGS) == 0x100, "SPI_REGS is the wrong size");
+
+/* Details for CMD register */
+
+#define SPI_CMD_USR                        BIT(18)
+
+/* Details for CTRL0 register */
+
+#define SPI_CTRL0_WR_BIT_ORDER             BIT(26)
+#define SPI_CTRL0_RD_BIT_ORDER             BIT(25)
+#define SPI_CTRL0_QIO_MODE                 BIT(24)
+#define SPI_CTRL0_DIO_MODE                 BIT(23)
+#define SPI_CTRL0_QOUT_MODE                BIT(20)
+#define SPI_CTRL0_DOUT_MODE                BIT(14)
+#define SPI_CTRL0_FASTRD_MODE              BIT(13)
+#define SPI_CTRL0_CLOCK_EQU_SYS_CLOCK      BIT(12)
+#define SPI_CTRL0_CLOCK_NUM_M              0x0000000F
+#define SPI_CTRL0_CLOCK_NUM_S              8
+#define SPI_CTRL0_CLOCK_HIGH_M             0x0000000F
+#define SPI_CTRL0_CLOCK_HIGH_S             4
+#define SPI_CTRL0_CLOCK_LOW_M              0x0000000F
+#define SPI_CTRL0_CLOCK_LOW_S              0
+
+/* Mask for the CLOCK_NUM/CLOCK_HIGH/CLOCK_LOW combined, in case one wants
+ * to set them all as a single value.
+ */
+#define SPI_CTRL0_CLOCK_M                  0x00000FFF
+#define SPI_CTRL0_CLOCK_S                  0
+
+/* Details for CTRL2 register */
+
+#define SPI_CTRL2_CS_DELAY_NUM_M           0x0000000F
+#define SPI_CTRL2_CS_DELAY_NUM_S           28
+#define SPI_CTRL2_CS_DELAY_MODE_M          0x00000003
+#define SPI_CTRL2_CS_DELAY_MODE_S          26
+#define SPI_CTRL2_MOSI_DELAY_NUM_M         0x00000007
+#define SPI_CTRL2_MOSI_DELAY_NUM_S         23
+#define SPI_CTRL2_MOSI_DELAY_MODE_M        0x00000003
+#define SPI_CTRL2_MOSI_DELAY_MODE_S        21
+#define SPI_CTRL2_MISO_DELAY_NUM_M         0x00000007
+#define SPI_CTRL2_MISO_DELAY_NUM_S         18
+#define SPI_CTRL2_MISO_DELAY_MODE_M        0x00000003
+#define SPI_CTRL2_MISO_DELAY_MODE_S        16
+
+/* Details for CLOCK register */
+
+#define SPI_CLOCK_EQU_SYS_CLOCK            BIT(31)
+#define SPI_CLOCK_DIV_PRE_M                0x00001FFF
+#define SPI_CLOCK_DIV_PRE_S                18
+#define SPI_CLOCK_COUNT_NUM_M              0x0000003F
+#define SPI_CLOCK_COUNT_NUM_S              12
+#define SPI_CLOCK_COUNT_HIGH_M             0x0000003F
+#define SPI_CLOCK_COUNT_HIGH_S             6
+#define SPI_CLOCK_COUNT_LOW_M              0x0000003F
+#define SPI_CLOCK_COUNT_LOW_S              0
+
+/* Mask for the COUNT_NUM/COUNT_HIGH/COUNT_LOW combined, in case one wants
+ * to set them all as a single value.
+ */
+#define SPI_CTRL0_COUNT_M                  0x0003FFFF
+#define SPI_CTRL0_COUNT_S                  0
+
+/* Details for USER0 register */
+
+#define SPI_USER0_COMMAND                  BIT(31)
+#define SPI_USER0_ADDR                     BIT(30)
+#define SPI_USER0_DUMMY                    BIT(29)
+#define SPI_USER0_MISO                     BIT(28)
+#define SPI_USER0_MOSI                     BIT(27)
+#define SPI_USER0_MOSI_HIGHPART            BIT(25)
+#define SPI_USER0_MISO_HIGHPART            BIT(24)
+#define SPI_USER0_SIO                      BIT(16)
+#define SPI_USER0_FWRITE_QIO               BIT(15)
+#define SPI_USER0_FWRITE_DIO               BIT(14)
+#define SPI_USER0_FWRITE_QUAD              BIT(13)
+#define SPI_USER0_FWRITE_DUAL              BIT(12)
+#define SPI_USER0_WR_BYTE_ORDER            BIT(11)
+#define SPI_USER0_RD_BYTE_ORDER            BIT(10)
+#define SPI_USER0_CLOCK_OUT_EDGE           BIT(7)
+#define SPI_USER0_CLOCK_IN_EDGE            BIT(6)
+#define SPI_USER0_CS_SETUP                 BIT(5)
+#define SPI_USER0_CS_HOLD                  BIT(4)
+#define SPI_USER0_FLASH_MODE               BIT(2)
+
+/* Details for USER1 register */
+
+#define SPI_USER1_ADDR_BITLEN_M            0x0000003F
+#define SPI_USER1_ADDR_BITLEN_S            26
+#define SPI_USER1_MOSI_BITLEN_M            0x000001FF
+#define SPI_USER1_MOSI_BITLEN_S            17
+#define SPI_USER1_MISO_BITLEN_M            0x000001FF
+#define SPI_USER1_MISO_BITLEN_S            8
+#define SPI_USER1_DUMMY_CYCLELEN_M         0x000000FF
+#define SPI_USER1_DUMMY_CYCLELEN_S         0
+
+/* Details for USER2 register */
+
+#define SPI_USER2_COMMAND_BITLEN_M         0x0000000F
+#define SPI_USER2_COMMAND_BITLEN_S         28
+#define SPI_USER2_COMMAND_VALUE_M          0x0000FFFF
+#define SPI_USER2_COMMAND_VALUE_S          0
+
+/* Details for PIN register */
+
+#define SPI_PIN_CS2_DISABLE                BIT(2)
+#define SPI_PIN_CS1_DISABLE                BIT(1)
+#define SPI_PIN_CS0_DISABLE                BIT(0)
+
+/* Details for SLAVE0 register */
+
+#define SPI_SLAVE0_SYNC_RESET              BIT(31)
+#define SPI_SLAVE0_MODE                    BIT(30)
+#define SPI_SLAVE0_WR_RD_BUF_EN            BIT(29)
+#define SPI_SLAVE0_WR_RD_STA_EN            BIT(28)
+#define SPI_SLAVE0_CMD_DEFINE              BIT(27)
+#define SPI_SLAVE0_TRANS_COUNT_M           0x0000000F
+#define SPI_SLAVE0_TRANS_COUNT_S           23
+#define SPI_SLAVE0_TRANS_DONE_EN           BIT(9)
+#define SPI_SLAVE0_WR_STA_DONE_EN          BIT(8)
+#define SPI_SLAVE0_RD_STA_DONE_EN          BIT(7)
+#define SPI_SLAVE0_WR_BUF_DONE_EN          BIT(6)
+#define SPI_SLAVE0_RD_BUF_DONE_EN          BIT(5)
+#define SPI_SLAVE0_INT_EN_M                0x0000001f
+#define SPI_SLAVE0_INT_EN_S                5
+#define SPI_SLAVE0_TRANS_DONE              BIT(4)
+#define SPI_SLAVE0_WR_STA_DONE             BIT(3)
+#define SPI_SLAVE0_RD_STA_DONE             BIT(2)
+#define SPI_SLAVE0_WR_BUF_DONE             BIT(1)
+#define SPI_SLAVE0_RD_BUF_DONE             BIT(0)
+
+/* Details for SLAVE1 register */
+
+#define SPI_SLAVE1_STATUS_BITLEN_M         0x0000001F
+#define SPI_SLAVE1_STATUS_BITLEN_S         27
+#define SPI_SLAVE1_BUF_BITLEN_M            0x000001FF
+#define SPI_SLAVE1_BUF_BITLEN_S            16
+#define SPI_SLAVE1_RD_ADDR_BITLEN_M        0x0000003F
+#define SPI_SLAVE1_RD_ADDR_BITLEN_S        10
+#define SPI_SLAVE1_WR_ADDR_BITLEN_M        0x0000003F
+#define SPI_SLAVE1_WR_ADDR_BITLEN_S        4
+#define SPI_SLAVE1_WRSTA_DUMMY_ENABLE      BIT(3)
+#define SPI_SLAVE1_RDSTA_DUMMY_ENABLE      BIT(2)
+#define SPI_SLAVE1_WRBUF_DUMMY_ENABLE      BIT(1)
+#define SPI_SLAVE1_RDBUF_DUMMY_ENABLE      BIT(0)
+
+/* Details for SLAVE2 register */
+
+#define SPI_SLAVE2_WRBUF_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_WRBUF_DUMMY_CYCLELEN_S  24
+#define SPI_SLAVE2_RDBUF_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_RDBUF_DUMMY_CYCLELEN_S  16
+#define SPI_SLAVE2_WRSTR_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_WRSTR_DUMMY_CYCLELEN_S  8
+#define SPI_SLAVE2_RDSTR_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_RDSTR_DUMMY_CYCLELEN_S  0
+
+/* Details for SLAVE3 register */
+
+#define SPI_SLAVE3_WRSTA_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_WRSTA_CMD_VALUE_S       24
+#define SPI_SLAVE3_RDSTA_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_RDSTA_CMD_VALUE_S       16
+#define SPI_SLAVE3_WRBUF_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_WRBUF_CMD_VALUE_S       8
+#define SPI_SLAVE3_RDBUF_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_RDBUF_CMD_VALUE_S       0
+
+/* Details for EXT3 register */
+
+#define SPI_EXT3_INT_HOLD_ENABLE_M         0x00000003
+#define SPI_EXT3_INT_HOLD_ENABLE_S         0
+
+#endif /* _SPI_REGS_H */

--- a/core/include/esp/uart_regs.h
+++ b/core/include/esp/uart_regs.h
@@ -43,7 +43,7 @@ struct UART_REGS {
     uint32_t volatile LOW_PULSE;      // 0x28
     uint32_t volatile HIGH_PULSE;     // 0x2c
     uint32_t volatile PULSE_COUNT;    // 0x30
-    uint32_t volatile _unused[18];    // 0x34 - 0x74
+    uint32_t volatile _unused[17];    // 0x34 - 0x74
     uint32_t volatile DATE;           // 0x78
     uint32_t volatile ID;             // 0x7c
 } __attribute__ (( packed ));

--- a/core/include/esp/uart_regs.h
+++ b/core/include/esp/uart_regs.h
@@ -1,0 +1,186 @@
+/** esp/uart.h
+ *
+ * Configuration of UART registers.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+
+#ifndef _UART_REGS_H
+#define _UART_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+/* Register definitions for the UART peripherals on the ESP8266.
+ *
+ * There are twp UART devices built into the ESP8266:
+ *   UART(0) is at 0x60000000
+ *   UART(1) is at 0x60000F00
+ *
+ * Each device is allocated a block of 64 32-bit registers (256 bytes of
+ * address space) to communicate with application code.
+ */
+
+#define UART_BASE 0x60000000
+#define UART(i) (*(struct UART_REGS *)(0x60000200 - (i)*0xf00))
+
+#define UART0_BASE UART_BASE
+#define UART1_BASE (UART_BASE + 0xf00)
+
+struct UART_REGS {
+    uint32_t volatile FIFO;           // 0x00
+    uint32_t volatile INT_RAW;        // 0x04
+    uint32_t volatile INT_STATUS;     // 0x08
+    uint32_t volatile INT_ENABLE;     // 0x0c
+    uint32_t volatile INT_CLEAR;      // 0x10
+    uint32_t volatile CLOCK_DIVIDER;  // 0x14
+    uint32_t volatile AUTOBAUD;       // 0x18
+    uint32_t volatile STATUS;         // 0x1c
+    uint32_t volatile CONF0;          // 0x20
+    uint32_t volatile CONF1;          // 0x24
+    uint32_t volatile LOW_PULSE;      // 0x28
+    uint32_t volatile HIGH_PULSE;     // 0x2c
+    uint32_t volatile PULSE_COUNT;    // 0x30
+    uint32_t volatile _unused[18];    // 0x34 - 0x74
+    uint32_t volatile DATE;           // 0x78
+    uint32_t volatile ID;             // 0x7c
+} __attribute__ (( packed ));
+
+_Static_assert(sizeof(struct UART_REGS) == 0x80, "UART_REGS is the wrong size");
+
+/* Details for FIFO register */
+
+#define UART_FIFO_DATA_M  0x000000ff
+#define UART_FIFO_DATA_S  0
+
+/* Details for INT_RAW register */
+
+#define UART_INT_RAW_RXFIFO_TIMEOUT          BIT(8)
+#define UART_INT_RAW_BREAK_DETECTED          BIT(7)
+#define UART_INT_RAW_CTS_CHANGED             BIT(6)
+#define UART_INT_RAW_DSR_CHANGED             BIT(5)
+#define UART_INT_RAW_RXFIFO_OVERFLOW         BIT(4)
+#define UART_INT_RAW_FRAMING_ERR             BIT(3)
+#define UART_INT_RAW_PARITY_ERR              BIT(2)
+#define UART_INT_RAW_TXFIFO_EMPTY            BIT(1)
+#define UART_INT_RAW_RXFIFO_FULL             BIT(0)
+
+/* Details for INT_STATUS register */
+
+#define UART_INT_STATUS_RXFIFO_TIMEOUT       BIT(8)
+#define UART_INT_STATUS_BREAK_DETECTED       BIT(7)
+#define UART_INT_STATUS_CTS_CHANGED          BIT(6)
+#define UART_INT_STATUS_DSR_CHANGED          BIT(5)
+#define UART_INT_STATUS_RXFIFO_OVERFLOW      BIT(4)
+#define UART_INT_STATUS_FRAMING_ERR          BIT(3)
+#define UART_INT_STATUS_PARITY_ERR           BIT(2)
+#define UART_INT_STATUS_TXFIFO_EMPTY         BIT(1)
+#define UART_INT_STATUS_RXFIFO_FULL          BIT(0)
+
+/* Details for INT_ENABLE register */
+
+#define UART_INT_ENABLE_RXFIFO_TIMEOUT       BIT(8)
+#define UART_INT_ENABLE_BREAK_DETECTED       BIT(7)
+#define UART_INT_ENABLE_CTS_CHANGED          BIT(6)
+#define UART_INT_ENABLE_DSR_CHANGED          BIT(5)
+#define UART_INT_ENABLE_RXFIFO_OVERFLOW      BIT(4)
+#define UART_INT_ENABLE_FRAMING_ERR          BIT(3)
+#define UART_INT_ENABLE_PARITY_ERR           BIT(2)
+#define UART_INT_ENABLE_TXFIFO_EMPTY         BIT(1)
+#define UART_INT_ENABLE_RXFIFO_FULL          BIT(0)
+
+/* Details for INT_CLEAR register */
+
+#define UART_INT_CLEAR_RXFIFO_TIMEOUT        BIT(8)
+#define UART_INT_CLEAR_BREAK_DETECTED        BIT(7)
+#define UART_INT_CLEAR_CTS_CHANGED           BIT(6)
+#define UART_INT_CLEAR_DSR_CHANGED           BIT(5)
+#define UART_INT_CLEAR_RXFIFO_OVERFLOW       BIT(4)
+#define UART_INT_CLEAR_FRAMING_ERR           BIT(3)
+#define UART_INT_CLEAR_PARITY_ERR            BIT(2)
+#define UART_INT_CLEAR_TXFIFO_EMPTY          BIT(1)
+#define UART_INT_CLEAR_RXFIFO_FULL           BIT(0)
+
+/* Details for CLOCK_DIVIDER register */
+
+#define UART_CLOCK_DIVIDER_VALUE_M           0x000fffff
+#define UART_CLOCK_DIVIDER_VALUE_S           0
+
+/* Details for AUTOBAUD register */
+
+#define UART_AUTOBAUD_GLITCH_FILTER_M        0x000000FF
+#define UART_AUTOBAUD_GLITCH_FILTER_S        8
+#define UART_AUTOBAUD_ENABLE                 BIT(0)
+
+/* Details for STATUS register */
+
+#define UART_STATUS_TXD                      BIT(31)
+#define UART_STATUS_RTS                      BIT(30)
+#define UART_STATUS_DTR                      BIT(29)
+#define UART_STATUS_TXFIFO_COUNT_M           0x000000ff
+#define UART_STATUS_TXFIFO_COUNT_S           16
+#define UART_STATUS_RXD                      BIT(15)
+#define UART_STATUS_CTS                      BIT(14)
+#define UART_STATUS_DSR                      BIT(13)
+#define UART_STATUS_RXFIFO_COUNT_M           0x000000ff
+#define UART_STATUS_RXFIFO_COUNT_S           0
+
+/* Details for CONF0 register */
+
+#define UART_CONF0_DTR_INVERTED              BIT(24)
+#define UART_CONF0_RTS_INVERTED              BIT(23)
+#define UART_CONF0_TXD_INVERTED              BIT(22)
+#define UART_CONF0_DSR_INVERTED              BIT(21)
+#define UART_CONF0_CTS_INVERTED              BIT(20)
+#define UART_CONF0_RXD_INVERTED              BIT(19)
+#define UART_CONF0_TXFIFO_RESET              BIT(18)
+#define UART_CONF0_RXFIFO_RESET              BIT(17)
+#define UART_CONF0_IRDA_ENABLE               BIT(16)
+#define UART_CONF0_TX_FLOW_ENABLE            BIT(15)
+#define UART_CONF0_LOOPBACK                  BIT(14)
+#define UART_CONF0_IRDA_RX_INVERTED          BIT(13)
+#define UART_CONF0_IRDA_TX_INVERTED          BIT(12)
+#define UART_CONF0_IRDA_WCTL                 BIT(11)
+#define UART_CONF0_IRDA_TX_ENABLE            BIT(10)
+#define UART_CONF0_IRDA_DUPLEX               BIT(9)
+#define UART_CONF0_TXD_BREAK                 BIT(8)
+#define UART_CONF0_SW_DTR                    BIT(7)
+#define UART_CONF0_SW_RTS                    BIT(6)
+#define UART_CONF0_STOP_BITS_M               0x00000003
+#define UART_CONF0_STOP_BITS_S               4
+#define UART_CONF0_BYTE_LEN_M                0x00000003
+#define UART_CONF0_BYTE_LEN_S                2
+#define UART_CONF0_PARITY_ENABLE             BIT(1)
+#define UART_CONF0_PARITY                    BIT(0) //FIXME: does this indicate odd or even?
+
+/* Details for CONF1 register */
+
+#define UART_CONF1_RX_TIMEOUT_ENABLE         BIT(31)
+#define UART_CONF1_RX_TIMEOUT_THRESHOLD_M    0x0000007f
+#define UART_CONF1_RX_TIMEOUT_THRESHOLD_S    24
+#define UART_CONF1_RX_FLOWCTRL_ENABLE        BIT(23)
+#define UART_CONF1_RX_FLOWCTRL_THRESHOLD_M   0x0000007f
+#define UART_CONF1_RX_FLOWCTRL_THRESHOLD_S   16
+#define UART_CONF1_TXFIFO_EMPTY_THRESHOLD_M  0x0000007f
+#define UART_CONF1_TXFIFO_EMPTY_THRESHOLD_S  8
+#define UART_CONF1_RXFIFO_FULL_THRESHOLD_M   0x0000007f
+#define UART_CONF1_RXFIFO_FULL_THRESHOLD_S   0
+
+/* Details for LOW_PULSE register */
+
+#define UART_LOW_PULSE_MIN_M                 0x000fffff
+#define UART_LOW_PULSE_MIN_S                 0
+
+/* Details for HIGH_PULSE register */
+
+#define UART_HIGH_PULSE_MIN_M                0x000fffff
+#define UART_HIGH_PULSE_MIN_S                0
+
+/* Details for PULSE_COUNT register */
+
+#define UART_PULSE_COUNT_VALUE_M             0x000003ff
+#define UART_PULSE_COUNT_VALUE_S             0
+
+#endif /* _UART_REGS_H */


### PR DESCRIPTION
(Re: issue #8)

Fleshing out a bunch more of the register headers:  Added *_regs.h files for UART, SPI, and RTC memory regions.  Also adding a bunch more register info to dport_regs.h based on info from http://esp8266-re.foogod.com/wiki/Memory_Map#dport0
