### PR TITLE
Remove packed attribute from register structs

### DIFF
--- a/core/include/common_macros.h
+++ b/core/include/common_macros.h
@@ -20,11 +20,20 @@
  * and shift) constants.  Used primarily with ESP8266 register access.
  */
 
-#define VAL2FIELD(fieldname, value) (((value) & fieldname##_M) << fieldname##_S)
+#define VAL2FIELD(fieldname, value) ((value) << fieldname##_S)
 #define FIELD2VAL(fieldname, regbits) (((regbits) >> fieldname##_S) & fieldname##_M)
 
 #define FIELD_MASK(fieldname) (fieldname##_M << fieldname##_S)
 #define SET_FIELD(regbits, fieldname, value) (((regbits) & ~FIELD_MASK(fieldname)) | VAL2FIELD(fieldname, value))
+
+/* VAL2FIELD/SET_FIELD do not normally check to make sure that the passed value
+ * will fit in the specified field (without clobbering other bits).  This makes
+ * them faster and is usually fine.  If you do need to make sure that the value
+ * will not overflow the field, use VAL2FIELD_M or SET_FIELD_M (which will
+ * first mask the supplied value to only the allowed number of bits) instead.
+ */
+#define VAL2FIELD_M(fieldname, value) (((value) & fieldname##_M) << fieldname##_S)
+#define SET_FIELD_M(regbits, fieldname, value) (((regbits) & ~FIELD_MASK(fieldname)) | VAL2FIELD_M(fieldname, value))
 
 /* Use this macro to store constant values in IROM flash instead
    of having them loaded into rodata (which resides in DRAM)

--- a/core/include/esp/dport_regs.h
+++ b/core/include/esp/dport_regs.h
@@ -45,7 +45,7 @@ struct DPORT_REGS {
     uint32_t volatile OTP_MAC1;            // 0x54
     uint32_t volatile OTP_CHIPID;          // 0x58
     uint32_t volatile OTP_MAC2;            // 0x5c
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct DPORT_REGS) == 0x60, "DPORT_REGS is the wrong size");
 

--- a/core/include/esp/gpio_regs.h
+++ b/core/include/esp/gpio_regs.h
@@ -57,7 +57,7 @@ struct GPIO_REGS {
     uint32_t volatile PWM;              // 0x68
     uint32_t volatile RTC_CALIB;        // 0x6c
     uint32_t volatile RTC_CALIB_RESULT; // 0x70
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct GPIO_REGS) == 0x74, "GPIO_REGS is the wrong size");
 

--- a/core/include/esp/iomux_regs.h
+++ b/core/include/esp/iomux_regs.h
@@ -20,7 +20,7 @@
 struct IOMUX_REGS {
     uint32_t volatile CONF;    // 0x00
     uint32_t volatile PIN[16]; // 0x04 - 0x40
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct IOMUX_REGS) == 0x44, "IOMUX_REGS is the wrong size");
 

--- a/core/include/esp/spi_regs.h
+++ b/core/include/esp/spi_regs.h
@@ -67,7 +67,7 @@ struct SPI_REGS {
     uint32_t volatile EXT1;         // 0xf4
     uint32_t volatile EXT2;         // 0xf8
     uint32_t volatile EXT3;         // 0xfc
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct SPI_REGS) == 0x100, "SPI_REGS is the wrong size");
 

--- a/core/include/esp/timer_regs.h
+++ b/core/include/esp/timer_regs.h
@@ -36,7 +36,7 @@ struct TIMER_REGS {            // FRC1  FRC2
     uint32_t volatile CTRL;    // 0x08  0x28
     uint32_t volatile STATUS;  // 0x0c  0x2c
     uint32_t volatile ALARM;   //       0x30
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct TIMER_REGS) == 0x14, "TIMER_REGS is the wrong size");
 

--- a/core/include/esp/uart_regs.h
+++ b/core/include/esp/uart_regs.h
@@ -46,7 +46,7 @@ struct UART_REGS {
     uint32_t volatile _unused[17];    // 0x34 - 0x74
     uint32_t volatile DATE;           // 0x78
     uint32_t volatile ID;             // 0x7c
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct UART_REGS) == 0x80, "UART_REGS is the wrong size");
 

--- a/core/include/esp/wdt_regs.h
+++ b/core/include/esp/wdt_regs.h
@@ -27,7 +27,7 @@ struct WDT_REGS {
     uint32_t volatile REG2;        // 0x08
     uint32_t volatile _unused[2];  // 0x0c - 0x10
     uint32_t volatile FEED;        // 0x14
-} __attribute__ (( packed ));
+};
 
 _Static_assert(sizeof(struct WDT_REGS) == 0x18, "WDT_REGS is the wrong size");
 


### PR DESCRIPTION
Per my comment on issue #8, `__attribute__ (( packed ))` can apparently cause GCC to do strange things with accesses under `-O0`, so this removes them (they shouldn't really be necessary anyway).

This also includes a patch to the VAL2FIELD / SET_FIELD macros to remove an AND operation which is probably rarely needed and makes them slightly less efficient than they need to be in general (I added VAL2FIELD_M / SET_FIELD_M which have the old behavior in case anything down the line actually does need it).