### PR TITLE
Fix broken UART(i) definition

### DIFF
--- a/core/include/esp/uart_regs.h
+++ b/core/include/esp/uart_regs.h
@@ -24,7 +24,7 @@
  */
 
 #define UART_BASE 0x60000000
-#define UART(i) (*(struct UART_REGS *)(0x60000200 - (i)*0xf00))
+#define UART(i) (*(struct UART_REGS *)(UART_BASE + (i)*0xf00))
 
 #define UART0_BASE UART_BASE
 #define UART1_BASE (UART_BASE + 0xf00)


### PR DESCRIPTION
Looks like I had a rather grievous cut/paste error in my previous uart_regs.h submission..