### PR TITLE
Added the ability to select stdout UART by modyfying STDOUT_UART.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -48,6 +48,9 @@ ESPTOOL ?= esptool.py
 ESPPORT ?= /dev/ttyUSB0
 ESPBAUD ?= 115200
 
+# Set STDOUT_UART to the UART number that will be used to output using printf/os_printf
+STDOUT_UART ?= 0
+
 # Set OTA to 1 to build an image that supports rBoot OTA bootloader
 #
 # Currently only works with 16mbit or more flash sizes, with 8mbit
@@ -100,7 +103,7 @@ ENTRY_SYMBOL ?= call_user_start
 SPLIT_SECTIONS ?= 1
 
 # Common flags for both C & C++_
-C_CXX_FLAGS     ?= -Wall -Werror -Wl,-EL -nostdlib $(EXTRA_C_CXX_FLAGS)
+C_CXX_FLAGS     ?= -Wall -Werror -Wl,-EL -nostdlib -DPRINT_UART=$(STDOUT_UART) $(EXTRA_C_CXX_FLAGS)
 # Flags for C only
 CFLAGS		?= $(C_CXX_FLAGS) -std=gnu99 $(EXTRA_CFLAGS)
 # Flags for C++ only

--- a/core/app_main.c
+++ b/core/app_main.c
@@ -165,7 +165,7 @@ void IRAM sdk_user_fatal_exception_handler(void) {
 
 
 static void IRAM default_putc(char c) {
-    uart_putc(0, c);
+    uart_putc(PRINT_UART, c);
 }
 
 // .text+0x258
@@ -232,6 +232,10 @@ void IRAM sdk_user_start(void) {
     sdk_SPIRead(ic_flash_addr, buf32, sizeof(struct sdk_g_ic_saved_st));
     Cache_Read_Enable(0, 0, 1);
     zero_bss();
+	// If user wants output through UART1, switch GPIO2 to U1TX function
+#if PRINT_UART == 1
+	PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO2_U, FUNC_U1TXD_BK);
+#endif
     sdk_os_install_putc1(default_putc);
     if (cksum_magic == 0xffffffff) {
         // No checksum required

--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -45,8 +45,8 @@ long _write_r(struct _reent *r, int fd, const char *ptr, int len )
         if(ptr[i] == '\r')
             continue;
         if(ptr[i] == '\n')
-            uart_putc(0, '\r');
-        uart_putc(0, ptr[i]);
+            uart_putc(PRINT_UART, '\r');
+        uart_putc(PRINT_UART, ptr[i]);
     }
     return len;
 }


### PR DESCRIPTION
I have modified the sources to be able to select UART1 TX (GPIO2) instead of UART0 to output messages using printf/os_printf. This way I can leave UART0 free for other tasks (like talking to a microcontroller using a binary protocol).

Not the most elegant patch you have seen for sure (involves modifying common.mk to pass a define to the compiler), but as syscalls must be modified for this to work, I couldn't think of a better way.

Feel free to merge the code if you find this useful (for me it is essential!).

And thanks for the great project, keep up the FOSS good work!