### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A community developed open source [FreeRTOS](http://www.freertos.org/)-based framework for ESP8266 WiFi-enabled microcontrollers. Intended for use in both commercial and open source projects.
 
-Originally based on, but substantially different from, the [Espressif IOT RTOS SDK](https://github.com/espressif/esp_iot_rtos_sdk).
+Originally based on, but substantially different from, the [Espressif IOT RTOS SDK](https://github.com/espressif/ESP8266_RTOS_SDK).
 
 ## Resources
 
@@ -12,7 +12,7 @@ Email discussion list: https://groups.google.com/d/forum/esp-open-rtos
 
 IRC channel: #esp-open-rtos on Freenode ([Web Chat Link](http://webchat.freenode.net/?channels=%23esp-open-rtos&uio=d4)).
 
-Github issues list/bugtracker: http://github.com/superhouse/esp-open-rtos/issues
+Github issues list/bugtracker: https://github.com/superhouse/esp-open-rtos/issues
 
 Please note that this project is released with a [Contributor Code of Conduct](https://github.com/SuperHouse/esp-open-rtos/blob/master/code_of_conduct.md). By participating in this project you agree to abide by its terms.
 
@@ -79,7 +79,7 @@ Current status is alpha quality, actively developed. AP STATION mode (ie wifi cl
 
 ## Open Source Components
 
-* [FreeRTOS](http://freertos.org) V7.5.2
+* [FreeRTOS](http://www.freertos.org/) V7.5.2
 * [lwIP](http://lwip.wikia.com/wiki/LwIP_Wiki) v1.4.1, modified via the [esp-lwip project](https://github.com/kadamski/esp-lwip) by @kadamski.
 * [newlib](https://github.com/projectgus/newlib-xtensa) v2.2.0, with patches for xtensa support and locking stubs for thread-safe operation on FreeRTOS.
 
@@ -126,7 +126,7 @@ If you are contributing code, *please ensure that it can be licensed under the B
 
 * Code from Espressif IoT SDK cannot be merged, as it is provided under either the "Espressif General Public License" or the "Espressif MIT License", which are not compatible with the BSD license.
 
-* Recent releases of the Espressif IoT RTOS SDK cannot be merged, as they changed from MIT License to the "Espressif MIT License" which is not BSD compatible. The Espressif binaries used in esp-open-rtos were taken from [revision ec75c85, as this was the last MIT Licensed revision](https://github.com/espressif/esp_iot_rtos_sdk/commit/43585fa74550054076bdf4bfe185e808ad0da83e).
+* Recent releases of the Espressif IoT RTOS SDK cannot be merged, as they changed from MIT License to the "Espressif MIT License" which is not BSD compatible. The Espressif binaries used in esp-open-rtos were taken from [revision ec75c85, as this was the last MIT Licensed revision](https://github.com/espressif/ESP8266_RTOS_SDK/commit/43585fa74550054076bdf4bfe185e808ad0da83e).
 
 For code submissions based on reverse engineered binary functionality, please either reverse engineer functionality from MIT Licensed Espressif releases or make sure that the reverse engineered code does not directly copy the code structure of the binaries - it cannot be a "derivative work" of an incompatible binary.
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/espressif/esp_iot_rtos_sdk | https://github.com/espressif/ESP8266_RTOS_SDK 
https://github.com/espressif/esp_iot_rtos_sdk/commit/43585fa74550054076bdf4bfe185e808ad0da83e | https://github.com/espressif/ESP8266_RTOS_SDK/commit/43585fa74550054076bdf4bfe185e808ad0da83e 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://github.com/superhouse/esp-open-rtos/issues | https://github.com/superhouse/esp-open-rtos/issues 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://freertos.org | http://www.freertos.org/ 
