### PR TITLE
Added possibility to enable internal pull-up resistors

### DIFF
--- a/extras/i2c/i2c.c
+++ b/extras/i2c/i2c.c
@@ -36,14 +36,21 @@
 #define CLK_STRETCH  (10)
 
 static bool started;
+static bool pullups;
 static uint8_t g_scl_pin;
 static uint8_t g_sda_pin;
 
 void i2c_init(uint8_t scl_pin, uint8_t sda_pin)
 {
     started = false;
+    pullups = false;
     g_scl_pin = scl_pin;
     g_sda_pin = sda_pin;
+}
+
+void i2c_pullups(bool enable)
+{
+	pullups = enable;
 }
 
 static void i2c_delay(void)
@@ -54,14 +61,14 @@ static void i2c_delay(void)
 // Set SCL as input and return current level of line, 0 or 1
 static bool read_scl(void)
 {
-    gpio_enable(g_scl_pin, GPIO_INPUT);
+    gpio_enable(g_scl_pin, pullups ? GPIO_INPUT_PULLUP : GPIO_INPUT);
     return gpio_read(g_scl_pin); // Clock high, valid ACK
 }
 
 // Set SDA as input and return current level of line, 0 or 1
 static bool read_sda(void)
 {
-    gpio_enable(g_sda_pin, GPIO_INPUT);
+    gpio_enable(g_sda_pin, pullups ? GPIO_INPUT_PULLUP : GPIO_INPUT);
     // TODO: Without this delay we get arbitration lost in i2c_stop
     i2c_delay();
     return gpio_read(g_sda_pin); // Clock high, valid ACK

--- a/extras/i2c/i2c.h
+++ b/extras/i2c/i2c.h
@@ -49,3 +49,7 @@ bool i2c_slave_read(uint8_t slave_addr, uint8_t data, uint8_t *buf, uint32_t len
 // devices where the i2c_slave_[read|write] functions above are of no use.
 void i2c_start(void);
 void i2c_stop(void);
+
+// Use internal pull-up resistors instead of external ones,
+// by default they are disabled.
+void i2c_pullups(bool enable);


### PR DESCRIPTION
I was working on an 5V I2C device (LCD screen) which had pull-up resistors on the SCL an SDA lines, since the ESP is not 5V tolerant I removed them. 3.3V is apparently enough in my application to make the slave recognise a logical 1.

This modification lets the user choose to enable the ESP internal pull-up resistors for the SCL and SDA lines with a new function: `i2c_pullups(boolean)`. This way the circuit does not need more external parts. ~~I have tested the code and checked the signal on an oscilloscope, despite the SCL line not rising to 3.3V it works well.~~ Edit: this is actually not reliable, but could work at slower speeds...

![I2C using ESP internal pull-up resistors](http://i.imgur.com/mxN0Ggo.jpg)

~~There's a risk in driving the SDA and SCL lines to Vcc. In my example I use a ESP8266-01 board where only the GPIO0 and 2 are available, just enough for I2C. GPIO0 must be connected to 0V when programming, but as soon as the program starts and drives the line to 3.3V it basically shorts Vcc to 0V via this GPIO0, an open-drain output allows for safety in this situation.~~

~~Ultimately driving the SCL and SDA lines to Vcc is a bad idea and should be removed I think (at least as the default configuration). If the slave drives the line to 0V for some reason it shorts out and the ESP probably dies, open-drain output is basically the whole point of I2C.~~

Never mind, the lines were never driven to Vcc, however internal pull-up resistors is still a neat feature.