### PR TITLE
fix sdk_bss_info STAILQ_ENTRY

### DIFF
--- a/include/espressif/esp_sta.h
+++ b/include/espressif/esp_sta.h
@@ -35,7 +35,7 @@ struct sdk_scan_config {
 };
 
 struct sdk_bss_info {
-    STAILQ_ENTRY(bss_info)     next;
+    STAILQ_ENTRY(sdk_bss_info)     next;
 
     uint8_t bssid[6];
     uint8_t ssid[32];


### PR DESCRIPTION
I'm certain this was an oversight... This is a needed change for the cgiwifi stuff in esphttpd.