### PR TITLE
Add WARNINGS_AS_ERRORS make flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ script:
   - cd ${TRAVIS_BUILD_DIR}
   # Remove ssid_config requirement for examples
   - sed -i "s%#warning%//#warning%" include/ssid_config.h
-  - make -C examples/ build-examples CROSS="ccache xtensa-lx106-elf-" V=1
+  - make WARNINGS_AS_ERRORS=1 -C examples/ build-examples CROSS="ccache xtensa-lx106-elf-" V=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,5 @@ before_install:
 script:
   - cd ${TRAVIS_BUILD_DIR}
   # Remove ssid_config requirement for examples
-  - sed -i "s%#warning%//#warning%" include/ssid_config.h
+  - sed -i "s%#error%//#error%" include/ssid_config.h
   - make WARNINGS_AS_ERRORS=1 -C examples/ build-examples CROSS="ccache xtensa-lx106-elf-" V=1

--- a/common.mk
+++ b/common.mk
@@ -106,8 +106,14 @@ ENTRY_SYMBOL ?= call_user_start
 # but compiled code size will come down a small amount.)
 SPLIT_SECTIONS ?= 1
 
+# Set this to 1 to have all compiler warnings treated as errors (and stop the
+# build).  This is recommended whenever you are working on code which will be
+# submitted back to the main project, as all submitted code will be expected to
+# compile without warnings to be accepted.
+WARNINGS_AS_ERRORS ?= 0
+
 # Common flags for both C & C++_
-C_CXX_FLAGS     ?= -Wall -Werror -Wl,-EL -nostdlib $(EXTRA_C_CXX_FLAGS)
+C_CXX_FLAGS ?= -Wall -Wl,-EL -nostdlib $(EXTRA_C_CXX_FLAGS)
 # Flags for C only
 CFLAGS		?= $(C_CXX_FLAGS) -std=gnu99 $(EXTRA_CFLAGS)
 # Flags for C++ only
@@ -117,6 +123,10 @@ CXXFLAGS	?= $(C_CXX_FLAGS) -fno-exceptions -fno-rtti $(EXTRA_CXXFLAGS)
 CPPFLAGS	+= -mlongcalls -mtext-section-literals
 
 LDFLAGS		= -nostdlib -Wl,--no-check-sections -L$(BUILD_DIR)sdklib -L$(ROOT)lib -u $(ENTRY_SYMBOL) -Wl,-static -Wl,-Map=$(BUILD_DIR)$(PROGRAM).map $(EXTRA_LDFLAGS)
+
+ifeq ($(WARNINGS_AS_ERRORS),1)
+    C_CXX_FLAGS += -Werror
+endif
 
 ifeq ($(SPLIT_SECTIONS),1)
   C_CXX_FLAGS += -ffunction-sections -fdata-sections

--- a/include/ssid_config.h
+++ b/include/ssid_config.h
@@ -20,7 +20,7 @@
 //   https://www.kernel.org/pub/software/scm/git/docs/git-update-index.html
 //
 
-#warning "You need to enter your wifi credentials in this file and follow the instructions here to keep the password safe from Github commits."
+#error "You need to enter your wifi credentials in this file and follow the instructions here to keep the password safe from Github commits."
 
 #ifndef __SSID_CONFIG_H__
 #define __SSID_CONFIG_H__


### PR DESCRIPTION
Previous behavior was all warnings were treated as errors.  This is now
controllable via a make variable and defaults to off (but can be turned on in
local.mk for those who still want the old behavior)