### PR TITLE
Fix Travis toolchain build (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   ESPTOOL2_COMMIT=ec0e2c7
   ESPTOOL2_DIR="${HOME}/esptool2-${ESPTOOL2_COMMIT}"
   PATH=${PATH}:${CROSS_BINDIR}:${ESPTOOL2_DIR}
+  CROSS="ccache xtensa-lx106-elf-"
+  MAKE_CMD="make WARNINGS_AS_ERRORS=1 -C examples/ build-examples"
 cache:
   directories:
     - ${CROSS_ROOT}
@@ -35,27 +37,12 @@ addons:
     - git
 
 before_install:
-  # Install a toolchain using esp-open-sdk (parts we need for this are the GNU toolchain and libhal)
-  #
-  # Adds hack of "{$HAS_TC} || -Buildstep-" to avoid rebuilding toolchain if it's already
-  # installed from the cache. If this gets any more complex it should be spun out to a standalone shell script.
-  - export HAS_TC="test -d ${CROSS_BINDIR}"
-  - unset CC # Travis sets this due to "language: c", but it confuses autotools configure when cross-building
-  - ${HAS_TC} || git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
-  - ${HAS_TC} || cd esp-open-sdk
-  - ${HAS_TC} || git reset --hard ${OPENSDK_COMMIT}
-  - ${HAS_TC} || git submodule update
-  - ${HAS_TC} || sed -i "s/2.69/2.68/" lx106-hal/configure.ac # this is a nasty hack as Ubuntu Precise only has autoconf 2.68 not 2.69...
-  - ${HAS_TC} || sed -r -i 's%TOOLCHAIN ?=.*%TOOLCHAIN=${CROSS_ROOT}%' Makefile
-  - ${HAS_TC} || make toolchain esptool libhal STANDALONE=n
-  - export HAS_ET2="test -f ${ESPTOOL2_DIR}/esptool2"
-  - ${HAS_ET2} || git clone https://github.com/raburton/esptool2 ${ESPTOOL2_DIR}
-  - ${HAS_ET2} || cd ${ESPTOOL2_DIR}
-  - ${HAS_ET2} || git reset --hard ${ESPTOOL2_COMMIT}
-  - ${HAS_ET2} || make
+  - utils/travis_build/install_esptool2.sh
+  - travis_wait 30 utils/travis_build/install_toolchain.sh
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
   # Remove ssid_config requirement for examples
   - sed -i "s%#error%//#error%" include/ssid_config.h
-  - make WARNINGS_AS_ERRORS=1 -C examples/ build-examples CROSS="ccache xtensa-lx106-elf-" V=1
+  # Don't verbose-build all examples (too much output), only verbose-build errors
+  - ( ${MAKE_CMD} ) || ( ${MAKE_CMD} V=1 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: false
 env:
   # Target commit for https://github.com/pfalcon/esp-open-sdk/
-  OPENSDK_COMMIT=e33c0ad3
+  OPENSDK_COMMIT=a48b12f
   CROSS_ROOT="${HOME}/toolchain-${OPENSDK_COMMIT}"
   CROSS_BINDIR="${CROSS_ROOT}/bin"
   ESPTOOL2_COMMIT=ec0e2c7

--- a/core/app_main.c
+++ b/core/app_main.c
@@ -411,7 +411,7 @@ extern void (*__init_array_start)(void);
 extern void (*__init_array_end)(void);
 
 // .Lfunc009 -- .irom0.text+0x5b4
-static void user_start_phase2(void) {
+static __attribute__((noinline)) void user_start_phase2(void) {
     uint8_t *buf;
     uint8_t *phy_info;
 
@@ -483,7 +483,7 @@ static void dump_flash_sector(uint32_t start_sector, uint32_t length) {
 }
 
 // .Lfunc011 -- .irom0.text+0x790
-static void dump_flash_config_sectors(uint32_t start_sector) {
+static __attribute__((noinline)) void dump_flash_config_sectors(uint32_t start_sector) {
     printf("system param error\n");
     // Note: original SDK code didn't dump PHY info
     printf("phy_info:\n");

--- a/utils/travis_build/install_esptool2.sh
+++ b/utils/travis_build/install_esptool2.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -uv
+
+# Called by Travis to install esptool2 to generate OTA-compatible build
+# images
+
+if test -f ${ESPTOOL2_DIR}/esptool2; then
+	echo "Using cached esptool2"
+	exit 0
+fi
+
+git clone https://github.com/raburton/esptool2 ${ESPTOOL2_DIR}
+cd ${ESPTOOL2_DIR}
+git reset --hard ${ESPTOOL2_COMMIT}
+make

--- a/utils/travis_build/install_toolchain.sh
+++ b/utils/travis_build/install_toolchain.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euv
+
+# Called by Travis to install a toolchain using esp-open-sdk (parts we
+# ne for esp-open-rtos are the GNU toolchain, libhal, and esptool.py.)
+
+if test -d ${CROSS_BINDIR}; then
+	echo "Using cached toolchain in ${CROSS_BINDIR}"
+	exit 0
+fi
+
+# Travis sets this due to "language: c", but it confuses autotools configure when cross-building
+unset CC
+
+git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
+cd esp-open-sdk
+git reset --hard ${OPENSDK_COMMIT}
+git submodule update --init
+
+# this is a nasty hack as Ubuntu Precise only has autoconf 2.68 not 2.69...
+sed -i "s/2.69/2.68/" lx106-hal/configure.ac
+
+# build the toolchain relative to the CROSS_ROOT directory
+sed -r -i 's%TOOLCHAIN ?=.*%TOOLCHAIN=${CROSS_ROOT}%' Makefile
+
+# will dump log on failure
+echo "Building toolchain without live progress, as progress spinner fills up log..."
+
+if !( make toolchain esptool libhal STANDALONE=n 2>&1 > make.log ); then
+	cat make.log
+	echo "Exiting due to failed toolchain build"
+	exit 3
+fi
+
+echo "Toolchain build completed in ${CROSS_ROOT}."


### PR DESCRIPTION
This is similar to #126 - git history was rewritten on a submodule of esp-open-sdk (esp-lwip this time) so historical commits on esp-open-sdk no longer check out cleanly, and our Travis builds broke.

Failure seems to be compounded by the 4MB log limit in Travis - toolchain plus all examples build with V=1 can blow the 4MB limit, so there's a commit here to only build V=1 on a failing example.

Long-term we may need to find a different way to include a toolchain in Travis, as the way we're using esp-open-sdk (including a historical commit) doesn't seem like it's sustainable.
