### PR TITLE
Call DisconnectNetwork(...) before MQTT reconnect

### DIFF
--- a/examples/mqtt_client/mqtt_client.c
+++ b/examples/mqtt_client/mqtt_client.c
@@ -157,6 +157,7 @@ static void  mqtt_task(void *pvParameters)
                 break;
         }
         printf("Connection dropped, request restart\n\r");
+        DisconnectNetwork(&network);
         taskYIELD();
     }
 }


### PR DESCRIPTION
I noticed I could not reconnect to my RasPi MQTT server following a disconnect. Adding DisconnectNetwork(...) did the trick.