### PR TITLE
Seed libc PRNG from hardware RNG on reset

### DIFF
--- a/core/app_main.c
+++ b/core/app_main.c
@@ -21,6 +21,7 @@
 #include "esp/spi_regs.h"
 #include "esp/dport_regs.h"
 #include "esp/wdev_regs.h"
+#include "esp/hwrand.h"
 #include "os_version.h"
 
 #include "espressif/esp_common.h"
@@ -377,6 +378,8 @@ static __attribute__((noinline)) void user_start_phase2(void) {
     uart_flush_txfifo(1);
 
     init_networking(&phy_info, sdk_info.sta_mac_addr);
+
+    srand(hwrand()); /* seed libc rng */
 
     // Call gcc constructor functions
     void (**ctor)(void);


### PR DESCRIPTION
This should have been done ages ago as part of #3, it's my fault I overlooked it. Without this PR, rand() produces a very predictable series of numbers after reset.

The only place I know that it's used by default is for the WPA Key Nonce, which is currently identical following each reset. This does not have any bearing on TLS - mbedTLS uses its own entropy engine, which is tied directly to the hardware random number generator.

A better long term fix would be to make `srand()` a no-op and have `rand()` return `hwrand()` each time its called, but newlib doesn't provide an easy mechanism (that I can see, anyhow) to replace `rand()`. So sticking with this for now.

If you're relying on `rand()` heavily in your own code, suggest having a task regularly call `srand(hwrand() ^ rand());` in order to mix it up a bit - or just use `hwrand()`.

I was going to push this fix directly as it's minor, but I thought it best to make some noise about it and also get some review if possible - does anyone have other thoughts/comments/suggestions about how we're managing entropy?