### PR TITLE
Handling MQTT read failure and send buffer length

### DIFF
--- a/extras/paho_mqtt_c/MQTTClient.h
+++ b/extras/paho_mqtt_c/MQTTClient.h
@@ -27,7 +27,7 @@
 enum QoS { QOS0, QOS1, QOS2 };
 
 // all failure return codes must be negative
-enum returnCode {DISCONNECTED = -3, BUFFER_OVERFLOW = -2, FAILURE = -1, SUCCESS = 0 };
+enum returnCode {READ_ERROR = -4, DISCONNECTED = -3, BUFFER_OVERFLOW = -2, FAILURE = -1, SUCCESS = 0 };
 
 void NewTimer(Timer*);
 


### PR DESCRIPTION
Try resolve issue #152 
When a MQTT packet is being received but the packet length is larger than allocated buffer or reading timeout occurs, ignore that packet and reinitialize broker connection.
Caller have to pay attention to buffer size and timeout value in NewMQTTClient call. But at least ESP will not crash if timeout or receiving buffer overflow.
Also modified sending buffer length calculation bug.
I still don't like the way how Paho handles error. Seeking improvement in the future.
