### PR TITLE
SPIFFS: Selectable configuration of SPIFFS

### DIFF
--- a/examples/spiffs/Makefile
+++ b/examples/spiffs/Makefile
@@ -6,6 +6,8 @@ FLASH_SIZE = 32
 SPIFFS_BASE_ADDR = 0x200000
 SPIFFS_SIZE = 0x010000
 
+# SPIFFS_SINGLETON = 0  # for run-time configuration
+
 include ../../common.mk
 
 $(eval $(call make_spiffs_image,files))

--- a/examples/spiffs/spiffs_example.c
+++ b/examples/spiffs/spiffs_example.c
@@ -10,6 +10,14 @@
 #include "spiffs.h"
 #include "esp_spiffs.h"
 
+/**
+ * This example shows the default SPIFFS configuration when SPIFFS is
+ * configured in compile-time (SPIFFS_SINGLETON = 1).
+ *
+ * To configure SPIFFS in run-time uncomment SPIFFS_SINGLETON in the Makefile
+ * and replace the commented esp_spiffs_init in the code below.
+ *
+ */
 
 static void example_read_file_posix()
 {
@@ -76,7 +84,13 @@ static void example_fs_info()
 
 void test_task(void *pvParameters)
 {
+#if SPIFFS_SINGLETON == 1
     esp_spiffs_init();
+#else
+    // for run-time configuration when SPIFFS_SINGLETON = 0
+    esp_spiffs_init(0x200000, 0x10000);
+#endif
+
     if (esp_spiffs_mount() != SPIFFS_OK) {
         printf("Error mount SPIFFS\n");
     }

--- a/extras/spiffs/README.md
+++ b/extras/spiffs/README.md
@@ -11,15 +11,29 @@ of a flash memory.
  * SPIFFS - embedded file system for NOR flash memory.
  * POSIX file operations.
  * Static files upload to ESP8266 file system within build process.
- * SPIFFS singleton configuration. Only one instance of FS on a device.
+ * SPIFFS singleton or run-time configuration. Selectable by
+`SPIFFS_SINGLETON` variable in Makefile.
 
 ## Usage
+
+### Configuration
+
+SPIFFS can be configured in two ways. As a SINGLETON with configuration 
+parameters provided at compile-time. And during run-time. The default
+configuration is a SINGLETON. The desired configuration can be selected in
+program's Makefile with variable `SPIFFS_SINGLETON = 0`.
+
+If SPIFFS is configured in runtime (SPIFFS_SINGLETON = 0) the method 
+`esp_spiffs_init` accepts two arguments: address and size. Where address 
+and size is the location of SPIFFS region in SPI flash and its size.
 
 In order to use file system in a project the following steps should be made:
  * Add SPIFFS component in a project Makefile `EXTRA_COMPONENTS = extras/spiffs`
  * Specify your flash size in the Makefile `FLASH_SIZE = 32`
  * Specify the start address of file system region on the flash memory
-`SPIFFS_BASE_ADDR = 0x200000`
+`SPIFFS_BASE_ADDR = 0x200000`. It still needed even for `SPIFFS_SINGLETON = 0`
+in order to flash SPIFFS image to the right location during `make flash`.
+If no SPIFFS image is going to be flashed this variable can be omitted.
  * If you want to upload files to a file system during flash process specify
 the directory with files `$(eval $(call make_spiffs_image,files))`
 
@@ -63,8 +77,6 @@ with SPIFFS on a device.
 
 The build process will catch any changes in files directory and rebuild the
 image each time `make` is run.
-The build process will handle SPIFFS_SIZE change and rebuild **mkspiffs**
-utility and the image.
 
 ## Example
 

--- a/extras/spiffs/component.mk
+++ b/extras/spiffs/component.mk
@@ -1,7 +1,28 @@
 # Component makefile for extras/spiffs
 
+# If spiffs is configured as SINGLETON it must be configured in compile time.
+SPIFFS_SINGLETON ?= 1
+
 SPIFFS_BASE_ADDR ?= 0x300000
 SPIFFS_SIZE ?= 0x100000
+SPIFFS_LOG_PAGE_SIZE ?= 256
+SPIFFS_LOG_BLOCK_SIZE ?= 8192
+
+
+spiffs_CFLAGS += -DSPIFFS_SINGLETON=$(SPIFFS_SINGLETON)
+ifeq ($(SPIFFS_SINGLETON),1)
+# Singleton configuration
+spiffs_CFLAGS += -DSPIFFS_BASE_ADDR=$(SPIFFS_BASE_ADDR)
+spiffs_CFLAGS += -DSPIFFS_SIZE=$(SPIFFS_SIZE)
+endif
+
+spiffs_CFLAGS += -DSPIFFS_LOG_PAGE_SIZE=$(SPIFFS_LOG_PAGE_SIZE)
+spiffs_CFLAGS += -DSPIFFS_LOG_BLOCK_SIZE=$(SPIFFS_LOG_BLOCK_SIZE)
+
+# Main program needs SPIFFS definitions because it includes spiffs_config.h
+PROGRAM_CFLAGS += $(spiffs_CFLAGS)
+
+spiffs_CFLAGS := $(CFLAGS) $(spiffs_CFLAGS)
 
 INC_DIRS += $(spiffs_ROOT)
 INC_DIRS += $(spiffs_ROOT)spiffs/src
@@ -9,11 +30,6 @@ INC_DIRS += $(spiffs_ROOT)spiffs/src
 # args for passing into compile rule generation
 spiffs_SRC_DIR = $(spiffs_ROOT)spiffs/src
 spiffs_SRC_DIR += $(spiffs_ROOT)
-
-spiffs_CFLAGS = $(CFLAGS)
-spiffs_CFLAGS += -DSPIFFS_BASE_ADDR=$(SPIFFS_BASE_ADDR)
-spiffs_CFLAGS += -DSPIFFS_SIZE=$(SPIFFS_SIZE)
-
 
 # Create an SPIFFS image of specified directory and flash it with
 # the rest of the firmware.
@@ -33,31 +49,22 @@ all: $$(SPIFFS_IMAGE)
 
 clean: clean_spiffs_img clean_mkspiffs
 
-$$(SPIFFS_IMAGE): $$(MKSPIFFS) $$(SPIFFS_FILE_LIST)
-	$$< $(1) $$@
+$$(SPIFFS_IMAGE): $$(MKSPIFFS) $$(SPIFFS_FILE_LIST) Makefile
+	$$< -D $(1) -f $$@ -s $(SPIFFS_SIZE) -p $(SPIFFS_LOG_PAGE_SIZE) \
+		-b $(SPIFFS_LOG_BLOCK_SIZE)
 
 # Rebuild SPIFFS if Makefile is changed, where SPIFF_SIZE is defined
 $$(spiffs_ROOT)spiffs_config.h: Makefile
 	$$(Q) touch $$@
 
-$$(MKSPIFFS)_MAKE:
-	$$(MAKE) -C $$(MKSPIFFS_DIR) SPIFFS_SIZE=$(SPIFFS_SIZE)
-
-# if SPIFFS_SIZE in Makefile is changed rebuild mkspiffs
-$$(MKSPIFFS): Makefile
-	$$(MAKE) -C $$(MKSPIFFS_DIR) clean
-	$$(MAKE) -C $$(MKSPIFFS_DIR) SPIFFS_SIZE=$(SPIFFS_SIZE)
+$$(MKSPIFFS):
+	$$(MAKE) -C $$(MKSPIFFS_DIR)
 
 clean_spiffs_img:
 	$$(Q) rm -f $$(SPIFFS_IMAGE)
 
 clean_mkspiffs:
 	$$(Q) $$(MAKE) -C $$(MKSPIFFS_DIR) clean
-
-# run make for mkspiffs always
-all: $$(MKSPIFFS)_MAKE
-
-.PHONY: $$(MKSPIFFS)_MAKE
 
 SPIFFS_ESPTOOL_ARGS = $(SPIFFS_BASE_ADDR) $$(SPIFFS_IMAGE)
 endef

--- a/extras/spiffs/esp_spiffs.h
+++ b/extras/spiffs/esp_spiffs.h
@@ -12,12 +12,25 @@
 
 extern spiffs fs;
 
+#if SPIFFS_SINGLETON == 1
 /**
  * Prepare for SPIFFS mount.
  *
  * The function allocates all the necessary buffers.
  */
 void esp_spiffs_init();
+#else
+/**
+ * Prepare for SPIFFS mount.
+ *
+ * The function allocates all the necessary buffers.
+ *
+ * @param addr Base address for spiffs in flash memory.
+ * @param size File sistem size.
+ */
+void esp_spiffs_init(uint32_t addr, uint32_t size);
+#endif
+
 
 /**
  * Free all memory buffers that were used by SPIFFS.

--- a/extras/spiffs/mkspiffs/Makefile
+++ b/extras/spiffs/mkspiffs/Makefile
@@ -1,16 +1,3 @@
-# Check if SPIFFS_SIZE defined only if not cleaning
-ifneq ($(MAKECMDGOALS),clean)
-ifndef SPIFFS_SIZE
-define ERROR_MSG
-Variable SPIFFS_SIZE is not defined.
-Cannot build mkspiffs without SPIFFS_SIZE.
-Please specify it in your application Makefile.
-
-endef
-$(error $(ERROR_MSG))	
-endif
-endif
-
 # explicitly use gcc as in xtensa build environment it might be set to
 # cross compiler
 CC = gcc
@@ -27,8 +14,7 @@ OBJECTS := $(SOURCES:.c=.o)
 VPATH = ../spiffs/src
 
 CFLAGS += -I..
-CFLAGS += -DSPIFFS_BASE_ADDR=0   # for image base addr is start of the image
-CFLAGS += -DSPIFFS_SIZE=$(SPIFFS_SIZE)
+CFLAGS += -DSPIFFS_SINGLETON=0
 
 all: mkspiffs
 

--- a/extras/spiffs/mkspiffs/README.md
+++ b/extras/spiffs/mkspiffs/README.md
@@ -14,21 +14,22 @@ $(eval $(call make_spiffs_image,files))
 
 where *files* is the directory with files that should go into SPIFFS image.
 
-Or you can build mkspiffs manually with:
+mkspiffs can be built separately. Simply run `make` in the mkspiffs directory.
+
+To manually generate SPIFFS image from a directory SPIFFS configuration must be
+provided as command line arguments.
+
+Arguments:
+ * -D Directory with files that will be put in SPIFFS image.
+ * -f SPIFFS image file name.
+ * -s SPIFFS size.
+ * -p Logical page size.
+ * -b Logical block size.
+
+All arguments are mandatory.
+
+For example:
 
 ```
-make SPIFFS_SIZE=0x100000
-```
-
-mkspiffs cannot be built without specifying SPIFFS size because it uses the
-same SPIFFS sources as the firmware. And for the firmware SPIFFS size is
-compile time defined.
-
-Please note that if you change SPIFFS_SIZE you need to rebuild mkspiffs.
-The easiest way is to run `make clean` for you project.
-
-To manually generate SPIFFS image from directory, run:
-
-```
-mkspiffs DIRECTORY IMAGE_NAME
+mkspiffs -D ./my_files -f spiffs.img -s 0x10000 -p 256 -b 8192
 ```

--- a/extras/spiffs/spiffs_config.h
+++ b/extras/spiffs/spiffs_config.h
@@ -158,23 +158,26 @@ typedef unsigned char u8_t;
 #define SPIFFS_SINGLETON 1
 #endif
 
+// ESP8266 supports only sector erase, which is 4096 bytes
+#define SPIFFS_ESP_ERASE_SIZE       (4096)
+
 #if SPIFFS_SINGLETON
 // Instead of giving parameters in config struct, singleton build must
 // give parameters in defines below.
 #ifndef SPIFFS_CFG_PHYS_SZ
-#define SPIFFS_CFG_PHYS_SZ(ignore)        (SPIFFS_SIZE)
+#define SPIFFS_CFG_PHYS_SZ(ignore)          (SPIFFS_SIZE)
 #endif
 #ifndef SPIFFS_CFG_PHYS_ERASE_SZ
-#define SPIFFS_CFG_PHYS_ERASE_SZ(ignore)  (4*1024)
+#define SPIFFS_CFG_PHYS_ERASE_SZ(ignore)    (SPIFFS_ESP_ERASE_SIZE)
 #endif
 #ifndef SPIFFS_CFG_PHYS_ADDR
-#define SPIFFS_CFG_PHYS_ADDR(ignore)      (SPIFFS_BASE_ADDR)
+#define SPIFFS_CFG_PHYS_ADDR(ignore)        (SPIFFS_BASE_ADDR)
 #endif
 #ifndef SPIFFS_CFG_LOG_PAGE_SZ
-#define SPIFFS_CFG_LOG_PAGE_SZ(ignore)    (256)
+#define SPIFFS_CFG_LOG_PAGE_SZ(ignore)      (SPIFFS_LOG_PAGE_SIZE)
 #endif
 #ifndef SPIFFS_CFG_LOG_BLOCK_SZ
-#define SPIFFS_CFG_LOG_BLOCK_SZ(ignore)   (8*1024)
+#define SPIFFS_CFG_LOG_BLOCK_SZ(ignore)     (SPIFFS_LOG_BLOCK_SIZE)
 #endif
 #endif
 


### PR DESCRIPTION
In [PR#163](https://github.com/SuperHouse/esp-open-rtos/pull/163) was suggested to have ability to select how SPIFFS is configured, as a singleton during compile-time or during run-time. This PR adds this feature.

By default SPIFFS is configured as before at compile-time. If run-time configuration is needed `SPIFFS_SINGLETON=0` should be specified in program's Makefile. In that case `esp_spiffs_init` accepts two arguments: address and size of spiffs flash region.

Logical page size, block size and erase block size is still a compile time defined parameters. I don't see a use case when those parameters needs to be changed in run-time. If needed they can be redefined in program's Makefile as well.