### PR TITLE
iomux_set_function: remove the IOMUX_FUNC transform of the func argument

### DIFF
--- a/core/esp_spi.c
+++ b/core/esp_spi.c
@@ -30,32 +30,27 @@
 
 static bool _minimal_pins[2] = {false, false};
 
-inline static void _set_pin_function(uint8_t pin, uint32_t function)
-{
-    iomux_set_function(gpio_to_iomux(pin), function);
-}
-
 bool spi_init(uint8_t bus, spi_mode_t mode, uint32_t freq_divider, bool msb, spi_endianness_t endianness, bool minimal_pins)
 {
     switch (bus)
     {
         case 0:
-            _set_pin_function(_SPI0_MISO_GPIO, _SPI0_FUNC);
-            _set_pin_function(_SPI0_MOSI_GPIO, _SPI0_FUNC);
-            _set_pin_function(_SPI0_SCK_GPIO, _SPI0_FUNC);
+            gpio_set_iomux_function(_SPI0_MISO_GPIO, _SPI0_FUNC);
+            gpio_set_iomux_function(_SPI0_MOSI_GPIO, _SPI0_FUNC);
+            gpio_set_iomux_function(_SPI0_SCK_GPIO, _SPI0_FUNC);
             if (!minimal_pins)
             {
-                _set_pin_function(_SPI0_HD_GPIO, _SPI0_FUNC);
-                _set_pin_function(_SPI0_WP_GPIO, _SPI0_FUNC);
-                _set_pin_function(_SPI0_CS0_GPIO, _SPI0_FUNC);
+                gpio_set_iomux_function(_SPI0_HD_GPIO, _SPI0_FUNC);
+                gpio_set_iomux_function(_SPI0_WP_GPIO, _SPI0_FUNC);
+                gpio_set_iomux_function(_SPI0_CS0_GPIO, _SPI0_FUNC);
             }
             break;
         case 1:
-            _set_pin_function(_SPI1_MISO_GPIO, _SPI1_FUNC);
-            _set_pin_function(_SPI1_MOSI_GPIO, _SPI1_FUNC);
-            _set_pin_function(_SPI1_SCK_GPIO, _SPI1_FUNC);
+            gpio_set_iomux_function(_SPI1_MISO_GPIO, _SPI1_FUNC);
+            gpio_set_iomux_function(_SPI1_MOSI_GPIO, _SPI1_FUNC);
+            gpio_set_iomux_function(_SPI1_SCK_GPIO, _SPI1_FUNC);
             if (!minimal_pins)
-                _set_pin_function(_SPI1_CS0_GPIO, _SPI1_FUNC);
+                gpio_set_iomux_function(_SPI1_CS0_GPIO, _SPI1_FUNC);
             break;
         default:
             return false;

--- a/core/esp_spi.c
+++ b/core/esp_spi.c
@@ -23,8 +23,8 @@
 #define _SPI1_SCK_GPIO  14
 #define _SPI1_CS0_GPIO  15
 
-#define _SPI0_FUNC 1
-#define _SPI1_FUNC 2
+#define _SPI0_FUNC IOMUX_FUNC(1)
+#define _SPI1_FUNC IOMUX_FUNC(2)
 
 #define _SPI_BUF_SIZE 64
 

--- a/core/include/esp/gpio.h
+++ b/core/include/esp/gpio.h
@@ -143,6 +143,16 @@ static inline gpio_inttype_t gpio_get_interrupt(const uint8_t gpio_num)
     return (gpio_inttype_t)FIELD2VAL(GPIO_CONF_INTTYPE, GPIO.CONF[gpio_num]);
 }
 
+/* Set GPIO I/O Mux function.
+ * The 'func' is an IOMUX_GPIO<n>_FUNC_<function> value, see iomux_regs.h
+ */
+inline static void gpio_set_iomux_function(const uint8_t gpio_num, uint32_t func)
+{
+    uint8_t iomux_num = gpio_to_iomux(gpio_num);
+    uint32_t prev = IOMUX.PIN[iomux_num] & ~IOMUX_PIN_FUNC_MASK;
+    IOMUX.PIN[iomux_num] = func | prev;
+}
+
 #ifdef	__cplusplus
 }
 #endif

--- a/core/include/esp/iomux.h
+++ b/core/include/esp/iomux.h
@@ -43,10 +43,16 @@ inline static esp_reg_t gpio_iomux_reg(const uint8_t gpio_number)
     return &(IOMUX.PIN[gpio_to_iomux(gpio_number)]);
 }
 
+/**
+ * Set the I/O Mux function. The iomux_num is an IOMUX register number, see
+ * gpio_to_iomux to obtain the IOMUX register number of a GPIO number.
+ * The 'func' is an IOMUX_GPIO<n>_FUNC_<function> value, see iomux_regs.h
+ *
+ */
 inline static void iomux_set_function(uint8_t iomux_num, uint32_t func)
 {
     uint32_t prev = IOMUX.PIN[iomux_num] & ~IOMUX_PIN_FUNC_MASK;
-    IOMUX.PIN[iomux_num] = IOMUX_FUNC(func) | prev;
+    IOMUX.PIN[iomux_num] = func | prev;
 }
 
 inline static void iomux_set_direction_flags(uint8_t iomux_num, uint32_t dir_flags)
@@ -75,7 +81,7 @@ inline static void iomux_set_pullup_flags(uint8_t iomux_num, uint32_t pullup_fla
 inline static void iomux_set_gpio_function(uint8_t gpio_number, bool output_enable)
 {
     const uint8_t iomux_num = gpio_to_iomux(gpio_number);
-    const uint32_t func = iomux_num > 11 ? 0 : 3;
+    const uint32_t func = iomux_num > 11 ? IOMUX_FUNC(0) : IOMUX_FUNC(3);
     iomux_set_function(iomux_num, func);
     iomux_set_direction_flags(iomux_num, output_enable ? IOMUX_PIN_OUTPUT_ENABLE : 0);
 }

--- a/core/include/esp/iomux_regs.h
+++ b/core/include/esp/iomux_regs.h
@@ -47,11 +47,6 @@ _Static_assert(sizeof(struct IOMUX_REGS) == 0x44, "IOMUX_REGS is the wrong size"
 /* WARNING: Macro evaluates argument twice */
 #define IOMUX_FUNC(val) (VAL2FIELD_M(IOMUX_PIN_FUNC_LOW, val) | VAL2FIELD_M(IOMUX_PIN_FUNC_HIGH, val))
 
-/* WARNING: Macro evaluates argument twice */
-#define IOMUX_FUNC_VALUE(regbits) (FIELD2VAL(IOMUX_PIN_FUNC_LOW, regbits) | FIELD2VAL(IOMUX_PIN_FUNC_HIGH, regbits))
-
-#define IOMUX_SET_FUNC(regbits, funcval) (((regbits) & ~IOMUX_PIN_FUNC_MASK) | (funcval))
-
 #define IOMUX_GPIO0   IOMUX.PIN[12]
 #define IOMUX_GPIO1   IOMUX.PIN[5]
 #define IOMUX_GPIO2   IOMUX.PIN[13]


### PR DESCRIPTION
The allows the IOMUX_GPIO<n>_FUNC_<function> definitions to be used here which seems to be the result of discussions in https://github.com/SuperHouse/esp-open-rtos/pull/171