### PR TITLE
Fix for system_deep_sleep ignoring argument

### DIFF
--- a/include/etstimer.h
+++ b/include/etstimer.h
@@ -36,4 +36,8 @@ typedef struct ETSTimer_st {
     void *timer_arg;
 } ETSTimer;
 
+void sdk_ets_timer_setfn(ETSTimer *ptimer, ETSTimerFunc *pfunction, void *parg);
+void sdk_ets_timer_arm(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag);
+void sdk_ets_timer_disarm(ETSTimer *ptimer);
+
 #endif /* _ETSTIMER_H */


### PR DESCRIPTION
Fix for https://github.com/SuperHouse/esp-open-rtos/issues/176.

The problem was  that *sdk_os_timer_* timers use FreeRTOS timers underneath which do not pass a timer argument to the callback function. They pass FreeRTOS timer handle which should be used in function **pvTimerGetTimerID** to extract the actual argument.

*sdk_ets_timer_* timers do not use FreeRTOS timers and pass a timer argument directly into a callback function.