### PR TITLE
sysparam: remove IRAM declarations.

### DIFF
--- a/core/sysparam.c
+++ b/core/sysparam.c
@@ -116,12 +116,12 @@ static struct {
 
 /***************************** Internal routines *****************************/
 
-static inline IRAM sysparam_status_t _do_write(uint32_t addr, const void *data, size_t data_size) {
+static inline sysparam_status_t _do_write(uint32_t addr, const void *data, size_t data_size) {
     CHECK_FLASH_OP(sdk_spi_flash_write(addr, (void*) data, data_size));
     return SYSPARAM_OK;
 }
 
-static inline IRAM sysparam_status_t _do_verify(uint32_t addr, const void *data, void *buffer, size_t len) {
+static inline sysparam_status_t _do_verify(uint32_t addr, const void *data, void *buffer, size_t len) {
     CHECK_FLASH_OP(sdk_spi_flash_read(addr, buffer, len));
     if (memcmp(data, buffer, len)) {
         return SYSPARAM_ERR_IO;
@@ -130,7 +130,7 @@ static inline IRAM sysparam_status_t _do_verify(uint32_t addr, const void *data,
 }
 
 /*FIXME: Eventually, this should probably be implemented down at the SPI flash library layer, where it can just compare bytes/words straight from the SPI hardware buffer instead of allocating a whole separate temp buffer, reading chunks into that, and then doing a memcmp.. */
-static IRAM sysparam_status_t _write_and_verify(uint32_t addr, const void *data, size_t data_size) {
+static sysparam_status_t _write_and_verify(uint32_t addr, const void *data, size_t data_size) {
     int i;
     size_t count;
     sysparam_status_t status = SYSPARAM_OK;


### PR DESCRIPTION
Not sure why some of the functions had IRAM declarations, it appears unnecessary. These were in the flash write path but well above the critical section, and writes are expected to be a cold path, so perhaps it would be better to save some RAM.