### PR TITLE
Default flash parameters for 32M bit.

### DIFF
--- a/parameters.mk
+++ b/parameters.mk
@@ -10,7 +10,7 @@
 
 # Flash size in megabits
 # Valid values are same as for esptool.py - 2,4,8,16,32
-FLASH_SIZE ?= 16
+FLASH_SIZE ?= 32
 
 # Flash mode, valid values are same as for esptool.py - qio,qout,dio.dout
 FLASH_MODE ?= qio


### PR DESCRIPTION
Suits the Nodemcu and Witty, and many other common boards.

All the boards I am using are 32M bit and DIO. Might there be support to change these defaults?