### PR TITLE
paho_mqtt_c: refactor: rename symbols so they all have same prefix

### DIFF
--- a/examples/mqtt_client/mqtt_client.c
+++ b/examples/mqtt_client/mqtt_client.c
@@ -44,10 +44,10 @@ static void  beat_task(void *pvParameters)
     }
 }
 
-static void  topic_received(MessageData *md)
+static void  topic_received(mqtt_message_data_t *md)
 {
     int i;
-    MQTTMessage *message = md->message;
+    mqtt_message_t *message = md->message;
     printf("Received: ");
     for( i = 0; i < md->topic->lenstring.len; ++i)
         printf("%c", md->topic->lenstring.data[ i ]);
@@ -87,14 +87,14 @@ static const char *  get_my_id(void)
 static void  mqtt_task(void *pvParameters)
 {
     int ret         = 0;
-    struct Network network;
-    MQTTClient client   = DefaultClient;
+    struct mqtt_network network;
+    mqtt_client_t client   = mqtt_client_default;
     char mqtt_client_id[20];
     uint8_t mqtt_buf[100];
     uint8_t mqtt_readbuf[100];
-    MQTTPacket_connectData data = MQTTPacket_connectData_initializer;
+    mqtt_packet_connect_data_t data = mqtt_packet_connect_data_initializer;
 
-    NewNetwork( &network );
+    mqtt_network_new( &network );
     memset(mqtt_client_id, 0, sizeof(mqtt_client_id));
     strcpy(mqtt_client_id, "ESP-");
     strcat(mqtt_client_id, get_my_id());
@@ -104,14 +104,14 @@ static void  mqtt_task(void *pvParameters)
         printf("%s: started\n\r", __func__);
         printf("%s: (Re)connecting to MQTT server %s ... ",__func__,
                MQTT_HOST);
-        ret = ConnectNetwork(&network, MQTT_HOST, MQTT_PORT);
+        ret = mqtt_network_connect(&network, MQTT_HOST, MQTT_PORT);
         if( ret ){
             printf("error: %d\n\r", ret);
             taskYIELD();
             continue;
         }
         printf("done\n\r");
-        NewMQTTClient(&client, &network, 5000, mqtt_buf, 100,
+        mqtt_client_new(&client, &network, 5000, mqtt_buf, 100,
                       mqtt_readbuf, 100);
 
         data.willFlag       = 0;
@@ -122,15 +122,15 @@ static void  mqtt_task(void *pvParameters)
         data.keepAliveInterval  = 10;
         data.cleansession   = 0;
         printf("Send MQTT connect ... ");
-        ret = MQTTConnect(&client, &data);
+        ret = mqtt_connect(&client, &data);
         if(ret){
             printf("error: %d\n\r", ret);
-            DisconnectNetwork(&network);
+            mqtt_network_disconnect(&network);
             taskYIELD();
             continue;
         }
         printf("done\r\n");
-        MQTTSubscribe(&client, "/esptopic", QOS1, topic_received);
+        mqtt_subscribe(&client, "/esptopic", MQTT_QOS1, topic_received);
         xQueueReset(publish_queue);
 
         while(1){
@@ -139,25 +139,25 @@ static void  mqtt_task(void *pvParameters)
             while(xQueueReceive(publish_queue, (void *)msg, 0) ==
                   pdTRUE){
                 printf("got message to publish\r\n");
-                MQTTMessage message;
+                mqtt_message_t message;
                 message.payload = msg;
                 message.payloadlen = PUB_MSG_LEN;
                 message.dup = 0;
-                message.qos = QOS1;
+                message.qos = MQTT_QOS1;
                 message.retained = 0;
-                ret = MQTTPublish(&client, "/beat", &message);
-                if (ret != SUCCESS ){
+                ret = mqtt_publish(&client, "/beat", &message);
+                if (ret != MQTT_SUCCESS ){
                     printf("error while publishing message: %d\n", ret );
                     break;
                 }
             }
 
-            ret = MQTTYield(&client, 1000);
-            if (ret == DISCONNECTED)
+            ret = mqtt_yield(&client, 1000);
+            if (ret == MQTT_DISCONNECTED)
                 break;
         }
         printf("Connection dropped, request restart\n\r");
-        DisconnectNetwork(&network);
+        mqtt_network_disconnect(&network);
         taskYIELD();
     }
 }

--- a/extras/paho_mqtt_c/MQTTConnect.h
+++ b/extras/paho_mqtt_c/MQTTConnect.h
@@ -52,7 +52,7 @@ typedef union
 		unsigned int username : 1;			/**< 3.1 user name */
 	} bits;
 #endif
-} MQTTConnectFlags;	/**< connect flags byte */
+} mqtt_connect_flags_t;	/**< connect flags byte */
 
 
 
@@ -67,9 +67,9 @@ typedef struct
 	/** The version number of this structure.  Must be 0 */
 	int struct_version;
 	/** The LWT topic to which the LWT message will be published. */
-	MQTTString topicName;
+	mqtt_string_t topicName;
 	/** The LWT payload. */
-	MQTTString message;
+	mqtt_string_t message;
 	/**
       * The retained flag for the LWT message (see MQTTAsync_message.retained).
       */
@@ -79,10 +79,10 @@ typedef struct
       * MQTTAsync_message.qos and @ref qos).
       */
 	char qos;
-} MQTTPacket_willOptions;
+} mqtt_packet_will_options_t;
 
 
-#define MQTTPacket_willOptions_initializer { {'M', 'Q', 'T', 'W'}, 0, {NULL, {0, NULL}}, {NULL, {0, NULL}}, 0, 0 }
+#define mqtt_packet_will_options_initializer { {'M', 'Q', 'T', 'W'}, 0, {NULL, {0, NULL}}, {NULL, {0, NULL}}, 0, 0 }
 
 
 typedef struct
@@ -94,14 +94,14 @@ typedef struct
 	/** Version of MQTT to be used.  3 = 3.1 4 = 3.1.1
 	  */
 	unsigned char MQTTVersion;
-	MQTTString clientID;
+	mqtt_string_t clientID;
 	unsigned short keepAliveInterval;
 	unsigned char cleansession;
 	unsigned char willFlag;
-	MQTTPacket_willOptions will;
-	MQTTString username;
-	MQTTString password;
-} MQTTPacket_connectData;
+	mqtt_packet_will_options_t will;
+	mqtt_string_t username;
+	mqtt_string_t password;
+} mqtt_packet_connect_data_t;
 
 typedef union
 {
@@ -119,18 +119,18 @@ typedef union
 		unsigned int sessionpresent : 1;    /**< session present flag */
 	} bits;
 #endif
-} MQTTConnackFlags;	/**< connack flags byte */
+} mqtt_conn_ack_flags_t;	/**< connack flags byte */
 
-#define MQTTPacket_connectData_initializer { {'M', 'Q', 'T', 'C'}, 0, 4, {NULL, {0, NULL}}, 60, 1, 0, \
-		MQTTPacket_willOptions_initializer, {NULL, {0, NULL}}, {NULL, {0, NULL}} }
+#define mqtt_packet_connect_data_initializer { {'M', 'Q', 'T', 'C'}, 0, 4, {NULL, {0, NULL}}, 60, 1, 0, \
+		mqtt_packet_will_options_initializer, {NULL, {0, NULL}}, {NULL, {0, NULL}} }
 
-DLLExport int MQTTSerialize_connect(unsigned char* buf, int buflen, MQTTPacket_connectData* options);
-DLLExport int MQTTDeserialize_connect(MQTTPacket_connectData* data, unsigned char* buf, int len);
+DLLExport int mqtt_serialize_connect(unsigned char* buf, int buflen, mqtt_packet_connect_data_t* options);
+DLLExport int mqtt_deserialize_connect(mqtt_packet_connect_data_t* data, unsigned char* buf, int len);
 
-DLLExport int MQTTSerialize_connack(unsigned char* buf, int buflen, unsigned char connack_rc, unsigned char sessionPresent);
-DLLExport int MQTTDeserialize_connack(unsigned char* sessionPresent, unsigned char* connack_rc, unsigned char* buf, int buflen);
+DLLExport int mqtt_serialize_connack(unsigned char* buf, int buflen, unsigned char connack_rc, unsigned char sessionPresent);
+DLLExport int mqtt_deserialize_connack(unsigned char* sessionPresent, unsigned char* connack_rc, unsigned char* buf, int buflen);
 
-DLLExport int MQTTSerialize_disconnect(unsigned char* buf, int buflen);
-DLLExport int MQTTSerialize_pingreq(unsigned char* buf, int buflen);
+DLLExport int mqtt_serialize_disconnect(unsigned char* buf, int buflen);
+DLLExport int mqtt_serialize_pingreq(unsigned char* buf, int buflen);
 
 #endif /* MQTTCONNECT_H_ */

--- a/extras/paho_mqtt_c/MQTTESP8266.c
+++ b/extras/paho_mqtt_c/MQTTESP8266.c
@@ -28,7 +28,7 @@
 
 #include "MQTTESP8266.h"
 
-char  expired(Timer* timer)
+char  mqtt_timer_expired(mqtt_timer_t* timer)
 {
     portTickType now = xTaskGetTickCount();
     int32_t left = timer->end_time - now;
@@ -36,20 +36,20 @@ char  expired(Timer* timer)
 }
 
 
-void  countdown_ms(Timer* timer, unsigned int timeout)
+void  mqtt_timer_countdown_ms(mqtt_timer_t* timer, unsigned int timeout)
 {
     portTickType now = xTaskGetTickCount();
     timer->end_time = now + timeout / portTICK_RATE_MS;
 }
 
 
-void  countdown(Timer* timer, unsigned int timeout)
+void  mqtt_timer_countdown(mqtt_timer_t* timer, unsigned int timeout)
 {
-    countdown_ms(timer, timeout * 1000);
+    mqtt_timer_countdown_ms(timer, timeout * 1000);
 }
 
 
-int  left_ms(Timer* timer)
+int  mqtt_timer_left_ms(mqtt_timer_t* timer)
 {
     portTickType now = xTaskGetTickCount();
     int32_t left = timer->end_time - now;
@@ -57,14 +57,14 @@ int  left_ms(Timer* timer)
 }
 
 
-void  InitTimer(Timer* timer)
+void  mqtt_timer_init(mqtt_timer_t* timer)
 {
     timer->end_time = 0;
 }
 
 
 
-int  mqtt_esp_read(Network* n, unsigned char* buffer, int len, int timeout_ms)
+int  mqtt_esp_read(mqtt_network_t* n, unsigned char* buffer, int len, int timeout_ms)
 {
     struct timeval tv;
     fd_set fdset;
@@ -89,7 +89,7 @@ int  mqtt_esp_read(Network* n, unsigned char* buffer, int len, int timeout_ms)
 }
 
 
-int  mqtt_esp_write(Network* n, unsigned char* buffer, int len, int timeout_ms)
+int  mqtt_esp_write(mqtt_network_t* n, unsigned char* buffer, int len, int timeout_ms)
 {
     struct timeval tv;
     fd_set fdset;
@@ -115,7 +115,7 @@ int  mqtt_esp_write(Network* n, unsigned char* buffer, int len, int timeout_ms)
 
 
 
-void  NewNetwork(Network* n)
+void  mqtt_network_new(mqtt_network_t* n)
 {
     n->my_socket = -1;
     n->mqttread = mqtt_esp_read;
@@ -148,7 +148,7 @@ static int  host2addr(const char *hostname , struct in_addr *in)
 }
 
 
-int  ConnectNetwork(Network* n, const char* host, int port)
+int  mqtt_network_connect(mqtt_network_t* n, const char* host, int port)
 {
     struct sockaddr_in addr;
     int ret;
@@ -179,7 +179,7 @@ int  ConnectNetwork(Network* n, const char* host, int port)
 }
 
 
-int  DisconnectNetwork(Network* n)
+int  mqtt_network_disconnect(mqtt_network_t* n)
 {
     close(n->my_socket);
     n->my_socket = -1;

--- a/extras/paho_mqtt_c/MQTTESP8266.h
+++ b/extras/paho_mqtt_c/MQTTESP8266.h
@@ -24,36 +24,34 @@
 #include <FreeRTOS.h>
 #include <portmacro.h>
 
-typedef struct Timer Timer;
+typedef struct mqtt_timer mqtt_timer_t;
 
-struct Timer
+struct mqtt_timer
 {
     portTickType end_time;
 };
 
-typedef struct Network Network;
+typedef struct mqtt_network mqtt_network_t;
 
-struct Network
+struct mqtt_network
 {
 	int my_socket;
-	int (*mqttread) (Network*, unsigned char*, int, int);
-	int (*mqttwrite) (Network*, unsigned char*, int, int);
+	int (*mqttread) (mqtt_network_t*, unsigned char*, int, int);
+	int (*mqttwrite) (mqtt_network_t*, unsigned char*, int, int);
 };
 
-char expired(Timer*);
-void countdown_ms(Timer*, unsigned int);
-void countdown(Timer*, unsigned int);
-int left_ms(Timer*);
+char mqtt_timer_expired(mqtt_timer_t*);
+void mqtt_timer_countdown_ms(mqtt_timer_t*, unsigned int);
+void mqtt_timer_countdown(mqtt_timer_t*, unsigned int);
+int mqtt_timer_left_ms(mqtt_timer_t*);
+void mqtt_timer_init(mqtt_timer_t*);
 
-void InitTimer(Timer*);
+int mqtt_esp_read(mqtt_network_t*, unsigned char*, int, int);
+int mqtt_esp_write(mqtt_network_t*, unsigned char*, int, int);
+void mqtt_esp_disconnect(mqtt_network_t*);
 
-int mqtt_esp_read(Network*, unsigned char*, int, int);
-int mqtt_esp_write(Network*, unsigned char*, int, int);
-void mqtt_esp_disconnect(Network*);
-
-void NewNetwork(Network* n);
-int ConnectNetwork(Network* n, const char* host, int port);
-int DisconnectNetwork(Network* n);
-
+void mqtt_network_new(mqtt_network_t* n);
+int mqtt_network_connect(mqtt_network_t* n, const char* host, int port);
+int mqtt_network_disconnect(mqtt_network_t* n);
 
 #endif /* _MQTT_ESP8266_H_ */

--- a/extras/paho_mqtt_c/MQTTFormat.h
+++ b/extras/paho_mqtt_c/MQTTFormat.h
@@ -20,18 +20,18 @@
 #include "StackTrace.h"
 #include "MQTTPacket.h"
 
-const char* MQTTPacket_getName(unsigned short packetid);
-int MQTTStringFormat_connect(char* strbuf, int strbuflen, MQTTPacket_connectData* data);
-int MQTTStringFormat_connack(char* strbuf, int strbuflen, unsigned char connack_rc, unsigned char sessionPresent);
-int MQTTStringFormat_publish(char* strbuf, int strbuflen, unsigned char dup, int qos, unsigned char retained,
-		unsigned short packetid, MQTTString topicName, unsigned char* payload, int payloadlen);
-int MQTTStringFormat_ack(char* strbuf, int strbuflen, unsigned char packettype, unsigned char dup, unsigned short packetid);
-int MQTTStringFormat_subscribe(char* strbuf, int strbuflen, unsigned char dup, unsigned short packetid, int count,
-		MQTTString topicFilters[], int requestedQoSs[]);
-int MQTTStringFormat_suback(char* strbuf, int strbuflen, unsigned short packetid, int count, int* grantedQoSs);
-int MQTTStringFormat_unsubscribe(char* strbuf, int strbuflen, unsigned char dup, unsigned short packetid,
-		int count, MQTTString topicFilters[]);
-char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf, int buflen);
-char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf, int buflen);
+const char* mqtt_packet_get_name(unsigned short packetid);
+int mqtt_string_format_connect(char* strbuf, int strbuflen, mqtt_packet_connect_data_t* data);
+int mqtt_string_format_connack(char* strbuf, int strbuflen, unsigned char connack_rc, unsigned char sessionPresent);
+int mqtt_string_format_publish(char* strbuf, int strbuflen, unsigned char dup, int qos, unsigned char retained,
+		unsigned short packetid, mqtt_string_t topicName, unsigned char* payload, int payloadlen);
+int mqtt_string_format_ack(char* strbuf, int strbuflen, unsigned char packettype, unsigned char dup, unsigned short packetid);
+int mqtt_string_format_subscribe(char* strbuf, int strbuflen, unsigned char dup, unsigned short packetid, int count,
+		mqtt_string_t topicFilters[], int requestedQoSs[]);
+int mqtt_string_format_suback(char* strbuf, int strbuflen, unsigned short packetid, int count, int* grantedQoSs);
+int mqtt_string_format_unsubscribe(char* strbuf, int strbuflen, unsigned char dup, unsigned short packetid,
+		int count, mqtt_string_t topicFilters[]);
+char* mqtt_format_to_client_string(char* strbuf, int strbuflen, unsigned char* buf, int buflen);
+char* mqtt_format_to_server_string(char* strbuf, int strbuflen, unsigned char* buf, int buflen);
 
 #endif

--- a/extras/paho_mqtt_c/MQTTPacket.h
+++ b/extras/paho_mqtt_c/MQTTPacket.h
@@ -42,9 +42,20 @@ enum errors
 
 enum msgTypes
 {
-	CONNECT = 1, CONNACK, PUBLISH, PUBACK, PUBREC, PUBREL,
-	PUBCOMP, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK,
-	PINGREQ, PINGRESP, DISCONNECT
+	MQTTPACKET_CONNECT = 1,
+	MQTTPACKET_CONNACK,
+	MQTTPACKET_PUBLISH,
+	MQTTPACKET_PUBACK,
+	MQTTPACKET_PUBREC,
+	MQTTPACKET_PUBREL,
+	MQTTPACKET_PUBCOMP,
+	MQTTPACKET_SUBSCRIBE,
+	MQTTPACKET_SUBACK,
+	MQTTPACKET_UNSUBSCRIBE,
+	MQTTPACKET_UNSUBACK,
+	MQTTPACKET_PINGREQ,
+	MQTTPACKET_PINGRESP,
+	MQTTPACKET_DISCONNECT
 };
 
 /**
@@ -70,23 +81,23 @@ typedef union
 		unsigned int type : 4;			/**< message type nibble */
 	} bits;
 #endif
-} MQTTHeader;
+} mqtt_header_t;
 
 typedef struct
 {
 	int len;
 	char* data;
-} MQTTLenString;
+} mqtt_string_len_t;
 
 typedef struct
 {
 	char* cstring;
-	MQTTLenString lenstring;
-} MQTTString;
+	mqtt_string_len_t lenstring;
+} mqtt_string_t;
 
-#define MQTTString_initializer {NULL, {0, NULL}}
+#define mqtt_string_initializer {NULL, {0, NULL}}
 
-int MQTTstrlen(MQTTString mqttstring);
+int mqtt_strlen(mqtt_string_t mqttstring);
 
 #include "MQTTConnect.h"
 #include "MQTTPublish.h"
@@ -94,25 +105,25 @@ int MQTTstrlen(MQTTString mqttstring);
 #include "MQTTUnsubscribe.h"
 #include "MQTTFormat.h"
 
-int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char type, unsigned char dup, unsigned short packetid);
-int MQTTDeserialize_ack(unsigned char* packettype, unsigned char* dup, unsigned short* packetid, unsigned char* buf, int buflen);
+int mqtt_serialize_ack(unsigned char* buf, int buflen, unsigned char type, unsigned char dup, unsigned short packetid);
+int mqtt_deserialize_ack(unsigned char* packettype, unsigned char* dup, unsigned short* packetid, unsigned char* buf, int buflen);
 
-int MQTTPacket_len(int rem_len);
-int MQTTPacket_equals(MQTTString* a, char* b);
+int mqtt_packet_len(int rem_len);
+int mqtt_packet_equals(mqtt_string_t* a, char* b);
 
-int MQTTPacket_encode(unsigned char* buf, int length);
-int MQTTPacket_decode(int (*getcharfn)(unsigned char*, int), int* value);
-int MQTTPacket_decodeBuf(unsigned char* buf, int* value);
+int mqtt_packet_encode(unsigned char* buf, int length);
+int mqtt_packet_decode(int (*getcharfn)(unsigned char*, int), int* value);
+int mqtt_packet_decode_buf(unsigned char* buf, int* value);
 
-int readInt(unsigned char** pptr);
-char readChar(unsigned char** pptr);
-void writeChar(unsigned char** pptr, char c);
-void writeInt(unsigned char** pptr, int anInt);
-int readMQTTLenString(MQTTString* mqttstring, unsigned char** pptr, unsigned char* enddata);
-void writeCString(unsigned char** pptr, const char* string);
-void writeMQTTString(unsigned char** pptr, MQTTString mqttstring);
+int mqtt_read_int(unsigned char** pptr);
+char mqtt_read_char(unsigned char** pptr);
+void mqtt_write_char(unsigned char** pptr, char c);
+void mqtt_write_int(unsigned char** pptr, int anInt);
+int mqtt_read_str_len(mqtt_string_t* mqttstring, unsigned char** pptr, unsigned char* enddata);
+void mqtt_write_cstr(unsigned char** pptr, const char* string);
+void mqtt_write_mqqt_str(unsigned char** pptr, mqtt_string_t mqttstring);
 
-DLLExport int MQTTPacket_read(unsigned char* buf, int buflen, int (*getfn)(unsigned char*, int));
+DLLExport int mqtt_packet_read(unsigned char* buf, int buflen, int (*getfn)(unsigned char*, int));
 
 typedef struct {
 	int (*getfn)(void *, unsigned char*, int); /* must return -1 for error, 0 for call again, or the number of bytes read */
@@ -121,9 +132,9 @@ typedef struct {
 	int rem_len;
 	int len;
 	char state;
-}MQTTTransport;
+} mqtt_transport_t;
 
-int MQTTPacket_readnb(unsigned char* buf, int buflen, MQTTTransport *trp);
+int mqtt_packet_readnb(unsigned char* buf, int buflen, mqtt_transport_t *trp);
 
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
 }

--- a/extras/paho_mqtt_c/MQTTPublish.h
+++ b/extras/paho_mqtt_c/MQTTPublish.h
@@ -25,14 +25,14 @@
   #define DLLExport
 #endif
 
-DLLExport int MQTTSerialize_publish(unsigned char* buf, int buflen, unsigned char dup, int qos, unsigned char retained, unsigned short packetid,
-		MQTTString topicName, unsigned char* payload, int payloadlen);
+DLLExport int mqtt_serialize_publish(unsigned char* buf, int buflen, unsigned char dup, int qos, unsigned char retained, unsigned short packetid,
+		mqtt_string_t topicName, unsigned char* payload, int payloadlen);
 
-DLLExport int MQTTDeserialize_publish(unsigned char* dup, int* qos, unsigned char* retained, unsigned short* packetid, MQTTString* topicName,
+DLLExport int mqtt_deserialize_publish(unsigned char* dup, int* qos, unsigned char* retained, unsigned short* packetid, mqtt_string_t* topicName,
 		unsigned char** payload, int* payloadlen, unsigned char* buf, int len);
 
-DLLExport int MQTTSerialize_puback(unsigned char* buf, int buflen, unsigned short packetid);
-DLLExport int MQTTSerialize_pubrel(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid);
-DLLExport int MQTTSerialize_pubcomp(unsigned char* buf, int buflen, unsigned short packetid);
+DLLExport int mqtt_serialize_puback(unsigned char* buf, int buflen, unsigned short packetid);
+DLLExport int mqtt_serialize_pubrel(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid);
+DLLExport int mqtt_serialize_pubcomp(unsigned char* buf, int buflen, unsigned short packetid);
 
 #endif /* MQTTPUBLISH_H_ */

--- a/extras/paho_mqtt_c/MQTTSubscribe.h
+++ b/extras/paho_mqtt_c/MQTTSubscribe.h
@@ -25,15 +25,17 @@
   #define DLLExport
 #endif
 
-DLLExport int MQTTSerialize_subscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
-		int count, MQTTString topicFilters[], int requestedQoSs[]);
+#include "MQTTPacket.h"
 
-DLLExport int MQTTDeserialize_subscribe(unsigned char* dup, unsigned short* packetid,
-		int maxcount, int* count, MQTTString topicFilters[], int requestedQoSs[], unsigned char* buf, int len);
+DLLExport int mqtt_serialize_subscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
+		int count, mqtt_string_t topicFilters[], int requestedQoSs[]);
 
-DLLExport int MQTTSerialize_suback(unsigned char* buf, int buflen, unsigned short packetid, int count, int* grantedQoSs);
+DLLExport int mqtt_deserialize_subscribe(unsigned char* dup, unsigned short* packetid,
+		int maxcount, int* count, mqtt_string_t topicFilters[], int requestedQoSs[], unsigned char* buf, int len);
 
-DLLExport int MQTTDeserialize_suback(unsigned short* packetid, int maxcount, int* count, int grantedQoSs[], unsigned char* buf, int len);
+DLLExport int mqtt_serialize_suback(unsigned char* buf, int buflen, unsigned short packetid, int count, int* grantedQoSs);
+
+DLLExport int mqtt_deserialize_suback(unsigned short* packetid, int maxcount, int* count, int grantedQoSs[], unsigned char* buf, int len);
 
 
 #endif /* MQTTSUBSCRIBE_H_ */

--- a/extras/paho_mqtt_c/MQTTUnsubscribe.h
+++ b/extras/paho_mqtt_c/MQTTUnsubscribe.h
@@ -25,14 +25,14 @@
   #define DLLExport
 #endif
 
-DLLExport int MQTTSerialize_unsubscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
-		int count, MQTTString topicFilters[]);
+DLLExport int mqtt_serialize_unsubscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
+		int count, mqtt_string_t topicFilters[]);
 
-DLLExport int MQTTDeserialize_unsubscribe(unsigned char* dup, unsigned short* packetid, int max_count, int* count, MQTTString topicFilters[],
+DLLExport int mqtt_deserialize_unsubscribe(unsigned char* dup, unsigned short* packetid, int max_count, int* count, mqtt_string_t topicFilters[],
 		unsigned char* buf, int len);
 
-DLLExport int MQTTSerialize_unsuback(unsigned char* buf, int buflen, unsigned short packetid);
+DLLExport int mqtt_serialize_unsuback(unsigned char* buf, int buflen, unsigned short packetid);
 
-DLLExport int MQTTDeserialize_unsuback(unsigned short* packetid, unsigned char* buf, int len);
+DLLExport int mqtt_deserialize_unsuback(unsigned short* packetid, unsigned char* buf, int len);
 
 #endif /* MQTTUNSUBSCRIBE_H_ */


### PR DESCRIPTION
``` 
$ nm -g build/paho_mqtt_c.a | grep " T "
00000068 T mqtt_packet_decode
000000f4 T mqtt_packet_decode_buf
0000002c T mqtt_packet_encode
0000027c T mqtt_packet_equals
000000c4 T mqtt_packet_len
000002d4 T mqtt_packet_read
00000330 T mqtt_packet_readnb
00000120 T mqtt_read_char
0000010c T mqtt_read_int
00000208 T mqtt_read_str_len
00000254 T mqtt_strlen
00000130 T mqtt_write_char
00000180 T mqtt_write_cstr
00000144 T mqtt_write_int
000001c4 T mqtt_write_mqqt_str
000000f8 T mqtt_serialize_ack
00000170 T mqtt_serialize_puback
000001a4 T mqtt_serialize_pubcomp
0000001c T mqtt_serialize_publish
00000188 T mqtt_serialize_pubrel
00000420 T mqtt_client_new
000004cc T mqtt_connect
00000840 T mqtt_disconnect
00000730 T mqtt_publish
00000590 T mqtt_subscribe
00000688 T mqtt_unsubscribe
00000468 T mqtt_yield
00000108 T mqtt_deserialize_suback
0000001c T mqtt_serialize_subscribe
000000d0 T mqtt_deserialize_ack
00000010 T mqtt_deserialize_publish
000000e8 T mqtt_deserialize_unsuback
00000018 T mqtt_serialize_unsubscribe
0000000c T mqtt_esp_read
000000a8 T mqtt_esp_write
00000228 T mqtt_network_connect
000002d4 T mqtt_network_disconnect
00000200 T mqtt_network_new
0000019c T mqtt_timer_countdown
00000168 T mqtt_timer_countdown_ms
0000013c T mqtt_timer_expired
000001f0 T mqtt_timer_init
000001c0 T mqtt_timer_left_ms
0000023c T mqtt_deserialize_connack
00000050 T mqtt_serialize_connect
000002ec T mqtt_serialize_disconnect
00000300 T mqtt_serialize_pingreq
000002a8 T mqtt_serialize_zero
```

Also, renamed enum values (DISCONNECTED, FAILURE, SUCCESS are too generic to be in the global namespace). Added static qualifier where it is applicable.