### PR TITLE
esp/interrupts.h: Add RTC interrupt number.

### DIFF
--- a/core/include/esp/interrupts.h
+++ b/core/include/esp/interrupts.h
@@ -20,6 +20,7 @@ typedef enum {
     INUM_WDEV_FIQ = 0,
     INUM_SLC = 1,
     INUM_SPI = 2,
+    INUM_RTC = 3,
     INUM_GPIO = 4,
     INUM_UART = 5,
     INUM_TICK = 6, /* RTOS timer tick, possibly xtensa CPU CCOMPARE0(?) */


### PR DESCRIPTION
40002a58     $a3 = rtc_intr_handler
40002a5e     $a4 = 0x0
40002a60     $a2 = 0x3
40002a62     call ets_isr_attach