### PR TITLE
sysparam: export the 'compact' function, added it to the editor.

### DIFF
--- a/core/include/sysparam.h
+++ b/core/include/sysparam.h
@@ -138,6 +138,17 @@ sysparam_status_t sysparam_create_area(uint32_t base_addr, uint16_t num_sectors,
  */
 sysparam_status_t sysparam_get_info(uint32_t *base_addr, uint32_t *num_sectors);
 
+/** Compact the sysparam area.
+ *
+ *  This also flattens the log.
+ *
+ *  @retval ::SYSPARAM_OK           Completed successfully
+ *  @retval ::SYSPARAM_ERR_NOINIT   No current sysparam area is active
+ *  @retval ::SYSPARAM_ERR_CORRUPT  Sysparam region has bad/corrupted data
+ *  @retval ::SYSPARAM_ERR_IO       I/O error reading/writing flash
+ */
+sysparam_status_t sysparam_compact();
+
 /** Get the value associated with a key
  *
  *  This is the core "get value" function.  It will retrieve the value for the

--- a/examples/sysparam_editor/sysparam_editor.c
+++ b/examples/sysparam_editor/sysparam_editor.c
@@ -31,6 +31,7 @@ void usage(void) {
         "  <key>=<value>   -- Set <key> to text <value>\n"
         "  <key>:<hexdata> -- Set <key> to binary value represented as hex\n"
         "  dump            -- Show all currently set keys/values\n"
+        "  compact         -- Compact the sysparam area\n"
         "  reformat        -- Reinitialize (clear) the sysparam area\n"
         "  echo-off        -- Disable input echo\n"
         "  echo-on         -- Enable input echo\n"
@@ -211,6 +212,9 @@ void sysparam_editor_task(void *pvParameters) {
         } else if (!strcmp(cmd_buffer, "dump")) {
             printf("Dumping all params:\n");
             status = dump_params();
+        } else if (!strcmp(cmd_buffer, "compact")) {
+            printf("Compacting...\n");
+            status = sysparam_compact();
         } else if (!strcmp(cmd_buffer, "reformat")) {
             printf("Re-initializing region...\n");
             status = sysparam_create_area(base_addr, num_sectors, true);


### PR DESCRIPTION
Useful after editing parameters to get best read performance. Also to clear out the history, such as old passwords, but would take two calls for that.
