### PR TITLE
wifi_get/set_sleep_type: add source code implementations plus fixes.

### DIFF
--- a/include/espressif/esp_system.h
+++ b/include/espressif/esp_system.h
@@ -37,8 +37,8 @@ enum sdk_sleep_type {
     WIFI_SLEEP_LIGHT = 1,
     WIFI_SLEEP_MODEM = 2,
 };
-void sdk_wifi_set_sleep_type(enum sdk_sleep_type);
-enum sdk_sleep_type sdk_wifi_get_sleep_type(enum sdk_sleep_type);
+bool sdk_wifi_set_sleep_type(enum sdk_sleep_type);
+enum sdk_sleep_type sdk_wifi_get_sleep_type(void);
 
 void sdk_system_restore(void);
 void sdk_system_restart(void);

--- a/open_esplibs/libmain/user_interface.c
+++ b/open_esplibs/libmain/user_interface.c
@@ -592,4 +592,16 @@ void sdk_system_uart_de_swap()
     DPORT.PERI_IO &= ~DPORT_PERI_IO_SWAP_UART0_PINS;
 }
 
+enum sdk_sleep_type sdk_wifi_get_sleep_type()
+{
+    return sdk_pm_get_sleep_type();
+}
+
+bool sdk_wifi_set_sleep_type(enum sdk_sleep_type type)
+{
+    if (type > WIFI_SLEEP_MODEM) return false;
+    sdk_pm_set_sleep_type_from_upper(type);
+    return true;
+}
+
 #endif /* OPEN_LIBMAIN_USER_INTERFACE */


### PR DESCRIPTION
- wifi_set_sleep_type returns a bool success flag.
- wifi_get_sleep_type seemed useless, just returning an argument. Added an implementation using sdk_pm_get_sleep_type.
