### PR TITLE
Fix spiff and stdin_uart_interrupt overiding the same read function

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -134,9 +134,15 @@ $$($(1)_OBJ_DIR)%.o: $$($(1)_REAL_ROOT)%.S $$($(1)_MAKEFILE) $(wildcard $(ROOT)*
 	$$($(1)_CC_BASE) -c $$< -o $$@
 	$$($(1)_CC_BASE) -MM -MT $$@ -MF $$(@:.o=.d) $$<
 
-# the component is shown to depend on both obj and source files so we get a meaningful error message
-# for missing explicitly named source files
-$$($(1)_AR): $$($(1)_OBJ_FILES) $$($(1)_SRC_FILES)
+$(1)_AR_IN_FILES = $$($(1)_OBJ_FILES)
+
+# the component is shown to depend on both obj and source files so we get 
+# a meaningful error message for missing explicitly named source files
+ifeq ($(INCLUDE_SRC_IN_AR),1)
+   $(1)_AR_IN_FILES += $$($(1)_SRC_FILES)
+endif
+
+$$($(1)_AR): $$($(1)_AR_IN_FILES)
 	$(vecho) "AR $$@"
 	$(Q) mkdir -p $$(dir $$@)
 	$(Q) $(AR) cru $$@ $$^

--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -59,14 +59,9 @@ __attribute__((weak)) long _write_r(struct _reent *r, int fd, const char *ptr, i
 }
 
 /* syscall implementation for stdio read from UART */
-__attribute__((weak)) long _read_r( struct _reent *r, int fd, char *ptr, int len )
+__attribute__((weak)) long _read_stdin_r(struct _reent *r, int fd, char *ptr, int len)
 {
     int ch, i;
-
-    if(fd != r->_stdin->_file) {
-        r->_errno = EBADF;
-        return -1;
-    }
     uart_rxfifo_wait(0, 1);
     for(i = 0; i < len; i++) {
         ch = uart_getc_nowait(0);
@@ -74,6 +69,15 @@ __attribute__((weak)) long _read_r( struct _reent *r, int fd, char *ptr, int len
         ptr[i] = ch;
     }
     return i;
+}
+
+__attribute__((weak)) long _read_r( struct _reent *r, int fd, char *ptr, int len )
+{
+    if(fd != r->_stdin->_file) {
+        r->_errno = EBADF;
+        return -1;
+    }
+    return _read_stdin_r(r, fd, ptr, len);
 }
 
 /* Stub syscall implementations follow, to allow compiling newlib functions that

--- a/extras/spiffs/esp_spiffs.c
+++ b/extras/spiffs/esp_spiffs.c
@@ -141,21 +141,16 @@ long _write_r(struct _reent *r, int fd, const char *ptr, int len )
     return len;
 }
 
+// This function is weakly defined in core/newlib_syscalls.c
+long _read_stdin_r(struct _reent *r, int fd, char *ptr, int len);
+
 // This implementation replaces implementation in core/newlib_syscals.c
 long _read_r( struct _reent *r, int fd, char *ptr, int len )
 {
-    int ch, i;
-
     if(fd != r->_stdin->_file) {
         return SPIFFS_read(&fs, (spiffs_file)fd, ptr, len);
     }
-    uart_rxfifo_wait(0, 1);
-    for(i = 0; i < len; i++) {
-        ch = uart_getc_nowait(0);
-        if (ch < 0) break;
-        ptr[i] = ch;
-    }
-    return i;
+    return _read_stdin_r(r, fd, ptr, len);
 }
 
 int _open_r(struct _reent *r, const char *pathname, int flags, int mode)

--- a/extras/stdin_uart_interrupt/component.mk
+++ b/extras/stdin_uart_interrupt/component.mk
@@ -4,10 +4,12 @@
 # for 'usage' as this module is a drop-in replacement for the original polled
 # version of reading from the UART.
 
-INC_DIRS += $(ROOT)extras/stdin_uart_interrupt
+INC_DIRS += $(stdin_uart_interrupt_ROOT)
 
 # args for passing into compile rule generation
-extras/stdin_uart_interrupt_INC_DIR =  $(ROOT)extras/stdin_uart_interrupt
-extras/stdin_uart_interrupt_SRC_DIR =  $(ROOT)extras/stdin_uart_interrupt
+stdin_uart_interrupt_SRC_DIR = $(stdin_uart_interrupt_ROOT)
 
-$(eval $(call component_compile_rules,extras/stdin_uart_interrupt))
+INCLUDE_SRC_IN_AR = 0
+EXTRA_LDFLAGS = -Wl,--whole-archive $(stdin_uart_interrupt_AR) -Wl,--no-whole-archive
+
+$(eval $(call component_compile_rules,stdin_uart_interrupt))

--- a/extras/stdin_uart_interrupt/stdin_uart_interrupt.c
+++ b/extras/stdin_uart_interrupt/stdin_uart_interrupt.c
@@ -75,9 +75,9 @@ uint32_t uart0_num_char(void)
     return count;
 }
 
-// _read_r in core/newlib_syscalls.c will be skipped by the linker in favour
+// _read_stdin_r in core/newlib_syscalls.c will be skipped by the linker in favour
 // of this function
-long _read_r(struct _reent *r, int fd, char *ptr, int len)
+long _read_stdin_r(struct _reent *r, int fd, char *ptr, int len)
 {
     if (!inited) uart0_rx_init();
     for(int i = 0; i < len; i++) {

--- a/parameters.mk
+++ b/parameters.mk
@@ -42,6 +42,9 @@ PRINTF_SCANF_FLOAT_SUPPORT ?= 1
 
 FLAVOR ?= release # or debug
 
+# Include source files into a static library. It improves error messages.
+INCLUDE_SRC_IN_AR ?= 1
+
 # Compiler names, etc. assume gdb
 CROSS ?= xtensa-lx106-elf-
 


### PR DESCRIPTION
Fix for https://github.com/SuperHouse/esp-open-rtos/issues/248

In this PR function `_read_r` makes additional call to `_read_stdin_r`.
So, **stdin_uart_interrupt** can override only part that it is interested in.
Also **spiffs** overrides `_read_r`, handles file descriptors and leave stdin to `_read_stdin_r` whoever overrides it.
