### PR TITLE
Update and re-organise the sdk internal definitions.

### DIFF
--- a/FreeRTOS/Source/portable/esp8266/portmacro.h
+++ b/FreeRTOS/Source/portable/esp8266/portmacro.h
@@ -144,7 +144,7 @@ void PendSV(enum SVC_ReqType);
    ESPTODO: It may be possible to just read the 'ps' register instead
    of accessing thisvariable.
 */
-extern char sdk_NMIIrqIsOn;
+extern uint8_t sdk_NMIIrqIsOn;
 extern char level1_int_disabled;
 extern unsigned cpu_sr;
 

--- a/core/app_main.c
+++ b/core/app_main.c
@@ -26,8 +26,10 @@
 
 #include "espressif/esp_common.h"
 #include "espressif/phy_info.h"
-#include "sdk_internal.h"
 #include "esplibs/libmain.h"
+#include "esplibs/libnet80211.h"
+#include "esplibs/libphy.h"
+#include "esplibs/libpp.h"
 #include "sysparam.h"
 
 /* This is not declared in any header file (but arguably should be) */
@@ -296,11 +298,11 @@ static void init_g_ic(void) {
     }
     if (sdk_g_ic.s._unknown1e4._unknown1e4 == 0xffffffff) {
         bzero(&sdk_g_ic.s._unknown1e4, sizeof(sdk_g_ic.s._unknown1e4));
-        bzero(&sdk_g_ic.s._unknown20f, sizeof(sdk_g_ic.s._unknown20f));
+        bzero(&sdk_g_ic.s.sta_password, sizeof(sdk_g_ic.s.sta_password));
     }
     sdk_g_ic.s.wifi_led_enable = 0;
-    if (sdk_g_ic.s._unknown281 > 1) {
-        sdk_g_ic.s._unknown281 = 0;
+    if (sdk_g_ic.s.sta_bssid_set > 1) {
+        sdk_g_ic.s.sta_bssid_set = 0;
     }
     if (sdk_g_ic.s.ap_number > 5) {
         sdk_g_ic.s.ap_number = 1;
@@ -374,9 +376,9 @@ static __attribute__((noinline)) void user_start_phase2(void) {
     sdk_sleep_reset_analog_rtcreg_8266();
     get_otp_mac_address(sdk_info.sta_mac_addr);
     sdk_wifi_softap_cacl_mac(sdk_info.softap_mac_addr, sdk_info.sta_mac_addr);
-    sdk_info._unknown0 = 0x0104a8c0;
-    sdk_info._unknown4 = 0x00ffffff;
-    sdk_info._unknown8 = 0x0104a8c0;
+    sdk_info.softap_ipaddr.addr = 0x0104a8c0;  // 192.168.4.1
+    sdk_info.softap_netmask.addr = 0x00ffffff; // 255.255.255.0
+    sdk_info.softap_gw.addr = 0x0104a8c0;      // 192.168.4.1
     init_g_ic();
 
     read_saved_phy_info(&phy_info);

--- a/core/include/sdk_internal.h
+++ b/core/include/sdk_internal.h
@@ -14,23 +14,109 @@
 // 'info' is declared in app_main.o at .bss+0x4
 
 struct sdk_info_st {
-    uint32_t _unknown0;         // 0x00
-    uint32_t _unknown4;         // 0x04
-    uint32_t _unknown8;         // 0x08
-    ip_addr_t ipaddr;           // 0x0c
-    ip_addr_t netmask;          // 0x10
-    ip_addr_t gw;               // 0x14
+    ip_addr_t softap_ipaddr;    // 0x00
+    ip_addr_t softap_netmask;   // 0x04
+    ip_addr_t softap_gw;        // 0x08
+    ip_addr_t sta_ipaddr;       // 0x0c
+    ip_addr_t sta_netmask;      // 0x10
+    ip_addr_t sta_gw;           // 0x14
     uint8_t softap_mac_addr[6]; // 0x18
     uint8_t sta_mac_addr[6];    // 0x1e
 };
 
-extern struct sdk_info_st sdk_info;
 
-// 'rst_if' is declared in user_interface.o at .bss+0xfc
-extern struct sdk_rst_info sdk_rst_if;
+struct _unknown_info1 {
+    uint8_t _unknown00;
+    uint8_t _unknown01;
+    uint8_t _unknown02;
+    uint8_t _unknown03;
+    uint8_t _unknown04;
+    uint8_t _unknown05;
+    uint8_t channel; // eagle_auth_done
+};
 
-// 'g_ic' is declared in libnet80211/ieee80211.o at .bss+0x0
-// See also: http://esp8266-re.foogod.com/wiki/G_ic_(IoT_RTOS_SDK_0.9.9)
+
+struct _unknown_softap2 {
+    uint32_t _unknown00;
+    uint32_t _unknown04;
+    uint32_t _unknown08;
+    uint32_t _unknown0c;
+    uint32_t _unknown10[8]; // block copied from sdk_g_ic.s._unknown28c
+    uint32_t _unknown30;
+    uint32_t _unknown34;
+    uint32_t *_unknown38;
+    uint8_t *_unknown3c; // string copied from sdk_g_ic.s._unknown2ac
+    uint32_t _unknown40[29];
+    uint32_t _unknownb4; // 300
+    uint32_t _unknownb8[5];
+};
+
+
+struct _unknown_softap1 {
+    uint32_t _unknown00;
+    struct _unknown_softap2 *_unknown04;
+    uint32_t _unknown08[4];
+    uint32_t *_unknown18; // result of sdk_wpa_init, dynamically allocated object.
+};
+
+
+struct _unknown_wpa1 {
+    uint32_t _unknown00; // 1, 2, 3
+    uint32_t _unknown04; // 2
+    uint32_t _unknown08; // 10
+    uint32_t _unknown0c;
+    uint32_t _unknown10;
+    uint32_t _unknown14;
+    uint32_t _unknown18;
+    uint32_t _unknown1c;
+    uint32_t _unknown20; // 10
+    uint32_t _unknown24;
+    uint32_t _unknown28;
+    uint32_t _unknown2c;
+    uint32_t _unknown30;
+    uint32_t _unknown34;
+    uint32_t _unknown38;
+    uint32_t _unknown3c;
+    uint32_t _unknown40; // 2
+    uint32_t _unknown44;
+    uint32_t _unknown48;
+};
+
+
+struct sdk_netif_conninfo {
+    uint8_t mac_addr[6];
+    uint8_t _unknown07[2];
+
+    uint32_t _unknown08; // eagle_auth_done
+
+    uint32_t _unknown0c[3];
+
+    int8_t _unknown18; // eagle_auth_done
+    int8_t _unknown19;
+    int8_t _unknown1a;
+    int8_t _unknown1b;
+
+    uint32_t _unknown1c[23];
+
+    struct _unknown_info1 *_unknown78; // eagle_auth_done
+
+    uint32_t _unknown7c[8];
+
+    uint16_t _unknown9c; // ieee80211_hostap. increases by one one each timer func called.
+    uint16_t _unknown9e;
+
+    uint32_t _unknowna0[18];
+
+    int8_t _unknowne8; //
+    int8_t _unknowne9; // ppInstallKey
+    int8_t _unknownea;
+    int8_t _unknowneb;
+
+    uint32_t _unknownec[7];
+
+    uint32_t _unknown108; // hostap_handle_timer count
+};
+
 
 struct sdk_g_ic_netif_info {
     struct netif *netif;     // 0x00
@@ -38,15 +124,21 @@ struct sdk_g_ic_netif_info {
     uint8_t _unknown20[28];  // 0x20 - 0x3c
     uint32_t _unknown3c;     // 0x3c (referenced by sdk_wifi_station_disconnect)
     uint8_t _unknown40[6];   // 0x40 - 0x46
-    uint8_t _unknown46[66];  // 0x46 - 0x88
+    uint8_t _unknown46[2];   // 0x46 - 0x47
+    uint32_t _unknown48;     // 0x48
+    uint8_t _unknown4c;      // 0x4c
+    uint8_t _unknown4d[59];  // 0x4d - 0x88
     struct sdk_netif_conninfo *_unknown88;  // 0x88
     uint32_t _unknown8c;     // 0x8c
     struct sdk_netif_conninfo *conninfo[6]; // 0x90 - 0xa8
-    uint8_t _unknowna8[16];  // 0xa8 - 0xb8
-    uint8_t _unknownb8;      // 0xb8 (referenced by sdk_wifi_station_connect / sdk_wifi_station_disconnect)
-    uint8_t _unknownb9;      // 0xb9 (referenced by sdk_wifi_station_connect / sdk_wifi_station_disconnect)
-    uint8_t connect_status;  // 0xba (referenced by sdk_system_station_got_ip_set / sdk_wifi_station_disconnect)
+    uint8_t _unknowna8[12];  // 0xa8 - 0xb4
+    struct _unknown_softap1 *_unknownb4;
+    uint8_t statusb8;        // 0xb8 (arg of sta_status_set)
+    uint8_t statusb9;        // 0xb9 (compared to arg of sta_status_set)
+    uint8_t connect_status;  // 0xba (result of wifi_station_get_connect_status)
+    uint8_t started;         // 0xbb (referenced by sdk_wifi_station_start / sdk_wifi_station_stop)
 };
+
 
 // This is the portion of g_ic which is not loaded/saved to the flash ROM, and
 // starts out zeroed on every boot.
@@ -73,9 +165,11 @@ struct sdk_g_ic_volatile_st {
     uint8_t _unknown7e;
     uint8_t _unknown7f;
 
-    uint8_t _unknown80[204];
+    uint32_t _unknown80;
 
-    void *_unknown14c;
+    uint32_t _unknown84[50]; // wifi_softap_start, channels.
+
+    void * volatile _unknown14c; // wifi_softap_start, current channel, arg to ieee80211_chan2ieee
 
     uint8_t _unknown150[20];
 
@@ -92,8 +186,7 @@ struct sdk_g_ic_volatile_st {
     void *_unknown184;
     struct station_info *station_info_head;
     struct station_info *station_info_tail;
-    uint32_t _unknown190;
-    uint32_t _unknown194;
+    void *_unknown190[2]; // cnx_sta_leave
 
     uint8_t _unknown198[40];
 
@@ -112,9 +205,11 @@ struct sdk_g_ic_volatile_st {
     uint8_t _unknown1d5[3];
 };
 
+
 struct sdk_g_ic_unk0_st {
-    uint32_t _unknown1e4;
-    uint8_t _unknown1e8[32];
+    uint16_t _unknown1e4;  // sdk_wpa_config_profile
+    uint16_t _unknown1e6;  // sdk_wpa_config_profile
+    uint8_t sta_ssid[32];  // 0x1e8 Station ssid. Null terminated string.
 };
 
 // This is the portion of g_ic which is loaded/saved to the flash ROM, and thus
@@ -127,40 +222,45 @@ struct sdk_g_ic_saved_st {
     uint8_t wifi_mode;
     uint8_t wifi_led_enable;
     uint8_t wifi_led_gpio;
-    uint8_t _unknown1e3;
+    uint8_t wifi_led_state;  // 0 or 1.
 
     struct sdk_g_ic_unk0_st _unknown1e4;
 
     uint8_t _unknown208;
-    uint8_t _unknown209;
-    uint8_t _unknown20a;
+    uint8_t _unknown209; // sdk_wpa_config_profile
+    uint8_t _unknown20a; // sdk_wpa_config_profile
     uint8_t _unknown20b;
-    uint8_t _unknown20c;
+    uint8_t _unknown20c; // sdk_wpa_config_profile
     uint8_t _unknown20d;
     uint8_t _unknown20e;
-    uint8_t _unknown20f[64];
+    uint8_t sta_password[64]; // 0x20f Null terminated string.
     uint8_t _unknown24f;
 
     uint8_t _unknown250[49];
 
-    uint8_t _unknown281;
+    uint8_t sta_bssid_set; // 0x281 One if bssid is used, otherwise zero.
 
-    uint8_t _unknown282[6];
+    uint8_t sta_bssid[6]; // 0x282
 
-    uint32_t _unknown288;
+    uint16_t _unknown288;
+    uint16_t _unknown28a;
     uint8_t _unknown28c;
 
-    uint8_t _unknown28d[31];
+    uint8_t _unknown28d[21];
 
-    uint8_t _unknown2ac[64];
+    uint8_t _unknown2a0; // used in dhcp_bind_check wpa_main.o
+
+    uint8_t _unknown2a1[9];
+
+    char _unknown2ac[64]; // string.
     uint8_t _unknonwn2ec;
 
     uint8_t _unknown2ed[32];
 
-    uint8_t _unknown30d;
+    uint8_t _unknown30d; // result of ieee80211_chan2ieee
     uint8_t _unknown30e;
     uint8_t _unknown30f;
-    uint8_t _unknown310;
+    uint8_t _unknown310; // count of entries in the softap conninfo array, less two.
 
     uint8_t _unknown311[3];
 
@@ -194,7 +294,20 @@ struct sdk_g_ic_st {
     struct sdk_g_ic_saved_st    s; // 0x1d8 - 0x548
 };
 
-extern struct sdk_g_ic_st sdk_g_ic;
+
+
+struct esf_buf {
+    struct pbuf *pbuf1;    // 0x00
+    struct pbuf *pbuf2;    // 0x04
+    uint32_t *_unknown8_;  // 0x08
+    uint32_t *_unknownc_;  // 0x0c
+    uint8_t *frame;        // 0x10 IEEE-802.11 payload data?
+    uint16_t _unknown14_;  // 0x14
+    uint16_t length;       // 0x16
+    uint32_t *_unknown18_; // 0x18
+    struct esf_buf *next;  // 0x1c Free list.
+    void *extra;           // 0x20
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 // The above structures all refer to data regions outside our control, and a
@@ -205,35 +318,65 @@ extern struct sdk_g_ic_st sdk_g_ic;
 ///////////////////////////////////////////////////////////////////////////////
 
 _Static_assert(sizeof(struct sdk_info_st) == 0x24, "info_st is the wrong size!");
+_Static_assert(offsetof(struct sdk_info_st, sta_mac_addr) == 0x1e, "bad struct");
+
+_Static_assert(offsetof(struct _unknown_info1, channel) == 0x06, "bad struct");
+
+_Static_assert(sizeof(struct _unknown_softap2) == 0xcc, "_unknown_softap2 is the wrong size!");
+_Static_assert(offsetof(struct _unknown_softap2, _unknownb8) == 0xb8, "bad struct");
+
+_Static_assert(sizeof(struct _unknown_softap1) == 0x1c, "_unknown_softap1 is the wrong size!");
+_Static_assert(offsetof(struct _unknown_softap1, _unknown18) == 0x18, "bad struct");
+
+_Static_assert(sizeof(struct _unknown_wpa1) == 0x4c, "_unknown_wpa1 is the wrong size!");
+_Static_assert(offsetof(struct _unknown_wpa1, _unknown48) == 0x48, "bad struct");
+
+_Static_assert(offsetof(struct sdk_netif_conninfo, _unknown78) == 0x78, "bad struct");
+_Static_assert(offsetof(struct sdk_netif_conninfo, _unknown108) == 0x108, "bad struct");
+
+_Static_assert(offsetof(struct sdk_g_ic_netif_info, started) == 0xbb, "bad struct");
+
 _Static_assert(sizeof(struct sdk_g_ic_volatile_st) == 0x1d8, "sdk_g_ic_volatile_st is the wrong size!");
+_Static_assert(offsetof(struct sdk_g_ic_volatile_st, _unknown1d5) == 0x1d5, "bad struct");
+
 _Static_assert(sizeof(struct sdk_g_ic_saved_st) == 0x370, "sdk_g_ic_saved_st is the wrong size!");
+_Static_assert(offsetof(struct sdk_g_ic_saved_st, _unknown1e4) == 0x1e4 - 0x1d8, "bad struct");
+_Static_assert(offsetof(struct sdk_g_ic_saved_st, _unknown546) == 0x546 - 0x1d8, "bad struct");
+
 _Static_assert(sizeof(struct sdk_g_ic_st) == 0x548, "sdk_g_ic_st is the wrong size!");
 
-///////////////////////////////////////////////////////////////////////////////
-//                            Function Prototypes                            //
-///////////////////////////////////////////////////////////////////////////////
+_Static_assert(sizeof(struct esf_buf) == 0x24, "struct esf_buf: wrong size");
+_Static_assert(offsetof(struct esf_buf, extra) == 0x20, "bad struct");
+_Static_assert(offsetof(struct esf_buf, length) == 0x16, "bad struct");
 
-sdk_SpiFlashOpResult sdk_SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
-sdk_SpiFlashOpResult sdk_SPIWrite(uint32_t des_addr, uint32_t *src_addr, uint32_t size);
-void sdk_cnx_attach(struct sdk_g_ic_st *);
-void sdk_ets_timer_init(void);
-void sdk_ieee80211_ifattach(struct sdk_g_ic_st *, uint8_t *);
-void sdk_ieee80211_phy_init(enum sdk_phy_mode);
-void sdk_lmacInit(void);
-void sdk_phy_disable_agc(void);
-void sdk_phy_enable_agc(void);
-void sdk_pm_attach(void);
-void sdk_pp_attach(void);
-void sdk_pp_soft_wdt_init(void);
-int sdk_register_chipv6_phy(sdk_phy_info_t *);
-void sdk_sleep_reset_analog_rtcreg_8266(void);
-uint32_t sdk_system_get_checksum(uint8_t *, uint32_t);
-void sdk_wDevEnableRx(void);
-void sdk_wDev_Initialize(void);
-void sdk_wifi_mode_set(uint8_t);
-void sdk_wifi_softap_cacl_mac(uint8_t *, uint8_t *);
-void sdk_wifi_softap_set_default_ssid(void);
-void sdk_wifi_softap_start(void);
-void sdk_wifi_station_start(void);
+// The SDK access some slots in lwip structures.
+
+// The netif->state is initialized in netif_add within lwip with a struct
+// sdk_g_ic_netif_info, see sdk_wifi_station_start and sdk_wifi_softap_start.
+// There is a known sdk read of the netif->state in ieee80211_output.o
+// ieee80211_output_pbuf and perhaps elsewhere. The value is just passed through
+// lwip and and not used by lwip so just ensure this slot is at the expected
+// offset.
+_Static_assert(offsetof(struct netif, state) == 28, "netif->state offset wrong!");
+
+// Some sdk uses of netif->hwaddr have been converted to source code, but many
+// remain, but the content of this slot should not change in future versions of
+// lwip, so just ensure it is at the expected offset.
+_Static_assert(offsetof(struct netif, hwaddr) == 41, "netif->hwaddr offset wrong!");
+
+// Most sdk uses of the netif->flags have been converted to source code. One
+// known sdk binary read of the flags remains in wl_cnx.o:sdk_cnx_sta_leave
+// which checks the NETIF_FLAG_DHCP flag. The NETIF_FLAG_DHCP has been removed
+// in lwip v2, so some lwip hacks are needed to handle this for now until
+// wl_cnx.o is converted so source code too.
+_Static_assert(offsetof(struct netif, flags) == 47, "netif->flags offset wrong!");
+
+_Static_assert(offsetof(struct pbuf, eb) == 16, "pbuf->eb offset wrong!");
+
+
+/// Misc.
+
+err_t ethernetif_init(struct netif *netif);
+void ethernetif_input(struct netif *netif, struct pbuf *p);
 
 #endif /* _INTERNAL_SDK_STRUCTURES_H */

--- a/open_esplibs/include/esplibs/libmain.h
+++ b/open_esplibs/include/esplibs/libmain.h
@@ -6,26 +6,58 @@
    Copyright (C) 2015 Espressif Systems. Derived from MIT Licensed SDK libraries.
    BSD Licensed as described in the file LICENSE.
 */
-#include "sdk_internal.h"
+
 #ifndef _ESPLIBS_LIBMAIN_H
 #define _ESPLIBS_LIBMAIN_H
 
 #include "sdk_internal.h"
 
+// app_main.o
+extern uint8_t sdk_user_init_flag;
+extern struct sdk_info_st sdk_info;
+
+// ets_timer.o
+extern uint32_t sdk_debug_timer;
+extern void *sdk_debug_timerfn;
+void sdk_ets_timer_init(void);
+
 // misc.c
 int sdk_os_get_cpu_frequency(void);
-
 /* Don't call this function from user code, it doesn't change the CPU
  * speed. Call sdk_system_update_cpu_freq() instead. */
 void sdk_os_update_cpu_frequency(int freq);
 
-// user_interface.c
+// os_cpu_a.o
+
+// spi_flash.o
+extern sdk_flashchip_t sdk_flashchip;
+sdk_SpiFlashOpResult sdk_SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
+sdk_SpiFlashOpResult sdk_SPIWrite(uint32_t des_addr, uint32_t *src_addr, uint32_t size);
+
+// timers.o
+void sdk_os_timer_setfn(ETSTimer *ptimer, ETSTimerFunc *pfunction, void *parg);
+void sdk_os_timer_arm(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag);
+void sdk_os_timer_disarm(ETSTimer *ptimer);
+
+// uart.o
+void sdk_uart_div_modify(uint32_t uart_no, uint32_t new_divisor);
+
+// user_interface.o
+extern enum sdk_dhcp_status sdk_dhcpc_flag; // uint8_t in the sdk
+extern bool sdk_cpu_overclock;
+extern struct sdk_rst_info sdk_rst_if;
+extern sdk_wifi_promiscuous_cb_t sdk_promiscuous_cb;
 void sdk_system_restart_in_nmi(void);
 int sdk_system_get_test_result(void);
 void sdk_wifi_param_save_protect(struct sdk_g_ic_saved_st *data);
 bool sdk_system_overclock(void);
 bool sdk_system_restoreclock(void);
 uint32_t sdk_system_relative_time(uint32_t reltime);
+uint32_t sdk_system_get_checksum(uint8_t *, uint32_t);
+void sdk_wifi_softap_cacl_mac(uint8_t *, uint8_t *);
+void sdk_wifi_softap_set_default_ssid(void);
+
+// xtensa_context.o
 
 #endif /* _ESPLIBS_LIBMAIN_H */
 

--- a/open_esplibs/include/esplibs/libnet80211.h
+++ b/open_esplibs/include/esplibs/libnet80211.h
@@ -6,17 +6,90 @@
    Copyright (C) 2015 Espressif Systems. Derived from MIT Licensed SDK libraries.
    BSD Licensed as described in the file LICENSE.
 */
+
 #ifndef _ESPLIBS_LIBNET80211_H
 #define _ESPLIBS_LIBNET80211_H
 
-// Defined in wl_cnx.o
+#include "sdk_internal.h"
+
+// ieee80211_action.o
+
+// ieee80211_crypto_ccmp.o
+extern uint32_t sdk_ccmp;
+
+// ieee80211_crypto.o
+
+// ieee80211_crypto_tkip.o
+extern uint32_t sdk_tkip;
+
+// ieee80211_crypto_wep.o
+extern uint32_t sdk_wep;
+
+// ieee80211_ets.o
+struct esf_buf *sdk_ieee80211_getmgtframe(void **arg0, uint32_t arg1, uint32_t arg2);
+
+// ieee80211_hostap.o
+extern uint8_t sdk_TmpSTAAPCloseAP;
+extern uint8_t sdk_PendFreeBcnEb;
+void sdk_ieee80211_hostap_attach(struct sdk_g_ic_st *);
+void sdk_hostap_handle_timer(struct sdk_netif_conninfo *cnx_node);
+bool sdk_wifi_softap_start();
+bool sdk_wifi_softap_stop();
+
+// ieee80211_ht.o
+
+// ieee80211_input.o
+void sdk_ieee80211_deliver_data(struct sdk_g_ic_netif_info *netif_info, struct esf_buf *esf_buf);
+// The esf_buf is stored in the pbuf->eb slot.
+void sdk_ieee80211_deliver_data(struct sdk_g_ic_netif_info *netif_info, struct esf_buf *eb);
+
+// ieee80211.o
+extern struct sdk_g_ic_st sdk_g_ic;
+extern uint32_t sdk_xieee80211Queue;
+void sdk_ieee80211_ifattach(struct sdk_g_ic_st *, uint8_t *);
+void sdk_wifi_mode_set(uint8_t);
+
+// ieee80211_output.o
+int8_t sdk_ieee80211_output_pbuf(struct netif *ifp, struct pbuf* pb);
+void sdk_ieee80211_send_mgmt(struct sdk_g_ic_netif_info *info, int, int);
+struct esf_buf *sdk_ieee80211_beacon_alloc(struct sdk_g_ic_netif_info *, uint32_t *);
+
+// ieee80211_phy.o
+uint32_t sdk_ieee80211_phy_type_get();
+void sdk_ieee80211_phy_init(enum sdk_phy_mode);
+
+// ieee80211_power.o
+void sdk_ieee80211_pwrsave(void *, struct esf_buf *b);
+
+// ieee80211_proto.o
+extern uint8_t sdk_ieee80211_addr_bcast[6];
+
+// ieee80211_scan.o
+extern uint32_t sdk_ugScanStruct; // A struct.
+extern uint8_t sdk_auth_type;
+extern uint16_t sdk_scannum;
+void sdk_scan_cancel();
+
+// ieee80211_sta.o
+void sdk_ieee80211_sta_new_state(struct sdk_g_ic_st *, int, int);
+void sdk_sta_status_set(int status);
+bool sdk_wifi_station_start();
+bool sdk_wifi_station_stop();
+
+// wl_chm.o
+void sdk_chm_set_current_channel(uint32_t *);
+int sdk_ieee80211_chan2ieee(int *);
+int sdk_chm_check_same_channel();
+
+// wl_cnx.o
 extern ETSTimer sdk_sta_con_timer;
-
-// Defined in ieee80211_sta.o: .irom0.text+0xcc4
-bool sdk_wifi_station_stop(void);
-
-// Defined in ieee80211_hostap.o: .irom0.text+0x1184
-bool sdk_wifi_softap_stop(void);
+extern void *sdk_g_cnx_probe_rc_list_cb;
+void sdk_cnx_sta_leave(struct sdk_g_ic_netif_info *netif_info, void *);
+void *sdk_cnx_node_search(uint8_t mac[6]);
+void sdk_cnx_node_leave(struct sdk_g_ic_netif_info *netif, struct sdk_netif_conninfo *conn);
+void sdk_cnx_rc_update_state_metric(void *, int, int);
+void sdk_cnx_remove_rc(void *);
+void sdk_cnx_attach(struct sdk_g_ic_st *);
 
 #endif /* _ESPLIBS_LIBNET80211_H */
 

--- a/open_esplibs/include/esplibs/libphy.h
+++ b/open_esplibs/include/esplibs/libphy.h
@@ -9,8 +9,57 @@
 #ifndef _ESPLIBS_LIBPHY_H
 #define _ESPLIBS_LIBPHY_H
 
-// Defined in phy_chip_v6_ana.o: .irom0.text+0x12d8
+#include "sdk_internal.h"
+
+// phy_chip_v5_ana_romfunc.o
+
+// phy_chip_v5_cal_romfunc.o
+
+// phy_chip_v5_romfunc.o
+
+// phy_chip_v6_ana.o
 uint32_t sdk_test_tout(bool);
+uint32_t sdk_readvdd33();
+
+// phy_chip_v6_cal.o
+extern uint16_t sdk_loop_pwctrl_pwdet_error_accum_high_power;
+extern uint8_t sdk_tx_pwctrl_pk_num;
+extern uint8_t sdk_loop_pwctrl_correct_atten_high_power;
+extern uint8_t sdk_tx_pwctrl_set_chan_flag;
+extern uint8_t sdk_rxiq_cover_fail_num;
+
+// phy_chip_v6.o
+extern uint16_t sdk_tx_rf_ana_gain;
+extern uint32_t sdk_rxiq_compute_num;
+extern uint8_t sdk_rxdc_init_flag;
+extern uint32_t sdk_check_result;
+extern uint32_t sdk_chip6_sleep_params;
+extern uint8_t sdk_chip6_phy_init_ctrl;
+extern uint32_t sdk_phy_freq_offset;
+extern uint8_t sdk_do_pwctrl_flag;
+extern uint8_t sdk_pwctrl_debug;
+extern uint8_t sdk_txbk_dpdby_flag;
+extern uint8_t sdk_sw_scan_mode;
+extern uint32_t sdk_periodic_cal_dc_num;
+extern uint8_t sdk_periodic_cal_flag;
+extern uint8_t sdk_bbpll_cal_flag;
+extern uint8_t sdk_deep_sleep_en;
+int sdk_register_chipv6_phy(sdk_phy_info_t *);
+
+// phy_chip_v6_unused.o
+
+// phy.o
+void sdk_phy_disable_agc(void);
+void sdk_phy_enable_agc(void);
+
+// phy_sleep.o
+extern uint32_t sdk_chip_version;
+extern uint8_t sdk_periodic_cal_sat;
+extern uint8_t sdk_software_slp_reject;
+extern uint8_t sdk_SDIO_slp_reject;
+extern uint8_t sdk_hardware_reject;
+void sdk_sleep_reset_analog_rtcreg_8266(void);
+
 
 #endif /* _ESPLIBS_LIBPHY_H */
 

--- a/open_esplibs/include/esplibs/libpp.h
+++ b/open_esplibs/include/esplibs/libpp.h
@@ -9,31 +9,67 @@
 #ifndef _ESPLIBS_LIBPP_H
 #define _ESPLIBS_LIBPP_H
 
-// Located in wdev.o
-extern uint32_t sdk_WdevTimOffSet;
+#include "sdk_internal.h"
 
-// Defined in pp.o: .irom0.text+0xa08
-void sdk_ppRecycleRxPkt(void *);
+// esf_buf.o
+struct esf_buf *sdk_esf_rx_buf_alloc(uint32_t n); // n must be 7.
+struct esf_buf *sdk_esf_buf_alloc(void *, uint32_t n);
+void sdk_esf_buf_recycle(struct esf_buf *buf, int);
+void sdk_esf_buf_setup(void);
 
-// Defined in pm.o: .irom0.text+0x74
+// if_hwctrl.o
+extern uint8_t sdk_interface_mask;
+//extern ? sdk_if_ctrl;
+void sdk_ic_set_vif(int, int, uint8_t (*)[6], int, int);
+void sdk_ic_bss_info_update(int, uint8_t (*hwaddr)[], int, int);
+void sdk_ic_set_sta(int, int, void *, int, int, int, int, int);
+
+// lmac.o
+extern uint32_t sdk_lmacConfMib;
+void sdk_lmacInit(void);
+
+// mac_frame.o
+
+// pm.o
+struct esf_buf *sdk_ieee80211_getmgtframe(void **arg0, uint32_t arg1, uint32_t arg2);
+void sdk_pm_attach(void);
 uint32_t sdk_pm_rtc_clock_cali_proc(void);
-
-// Defined in pm.o: .irom0.text+0xb8
 void sdk_pm_set_sleep_time(uint32_t);
-
-// Defined in pm.o: .irom0.text+0x1758
 uint8_t sdk_pm_is_waked(void);
-
-// Defined in pm.o: .irom0.text+0x1774
 bool sdk_pm_is_open(void);
-
-// Defined in pm.o: .irom0.text+0x19ac
 bool sdk_pm_post(int);
+enum sdk_sleep_type sdk_pm_get_sleep_type(void);
+void sdk_pm_set_sleep_type_from_upper(enum sdk_sleep_type);
 
-// Defined in wdev.o: .irom0.text+0x450
+
+// pp.o
+extern uint16_t sdk_NoiseTimerInterval;
+extern uint16_t sdk_sleep_start_wait_time;
+extern uint8_t sdk_pend_flag_noise_check;
+extern uint8_t sdk_pend_flag_periodic_cal;
+extern uint8_t sdk_dbg_stop_sw_wdt;
+extern uint8_t sdk_dbg_stop_hw_wdt;
+bool sdk_ppRegisterTxCallback(void *, int);
+bool sdk_ppTxPkt(struct esf_buf *);
+void sdk_ppRecycleRxPkt(void *);
+void sdk_pp_attach(void);
+void sdk_pp_soft_wdt_init(void);
+void sdk_pp_soft_wdt_feed();
+void sdk_pp_post(int, int);
+
+// rate_control.o
+
+// trc.o
+
+// wdev.o
+extern uint8_t sdk_NMIIrqIsOn;
+extern uint32_t sdk_WdevTimOffSet;
+uint32_t sdk_wDev_Get_Next_TBTT();
+void sdk_wDev_Reset_TBTT();
+void sdk_wDev_SetRxPolicy(int, int, int);
+void sdk_wDevEnableRx(void);
+void sdk_wDev_Initialize(void);
 void sdk_wDev_MacTim1SetFunc(void (*func)(void));
-
-// Defined in wdev.o: .text+0x4a8
 void sdk_wDev_MacTim1Arm(uint32_t);
 
 #endif /* _ESPLIBS_LIBPP_H */

--- a/open_esplibs/include/esplibs/libwpa.h
+++ b/open_esplibs/include/esplibs/libwpa.h
@@ -1,0 +1,80 @@
+/* Internal function declarations for Espressif SDK libpp functions.
+
+   These are internal-facing declarations, it is not recommended to include these headers in your program.
+   (look at the headers in include/espressif/ instead and use these whenever possible.)
+
+   Copyright (C) 2015 Espressif Systems. Derived from MIT Licensed SDK libraries.
+   BSD Licensed as described in the file LICENSE.
+*/
+#ifndef _ESPLIBS_LIBWPA_H
+#define _ESPLIBS_LIBWPA_H
+
+#include "sdk_internal.h"
+
+// aes-internal-dec.o
+
+// aes-internal-enc.o
+
+// aes-internal.o
+
+// aes-unwrap.o
+
+// aes-wrap.o
+
+// ap_config.o
+
+// Seems to be passed 3 args, but only uses 2?
+int sdk_hostapd_setup_wpa_psk(struct _unknown_softap2 *);
+
+// common.o
+
+// ieee802_1x.o
+
+// md5-internal.o
+
+// md5.o
+
+// os_xtensa.o
+
+// rc4.o
+
+// sha1-internal.o
+
+// sha1.o
+
+// sha1-pbkdf2.o
+
+// sta_info.o
+
+// wpa_auth_ie.o
+
+// wpa_auth.o
+uint32_t *sdk_wpa_init(uint8_t (*hwaddr)[], struct _unknown_wpa1 *, int);
+
+// wpabuf.o
+
+// wpa_common.o
+
+// wpa_debug.o
+
+// wpa_ie.o
+
+// wpa_main
+void sdk_ppInstallKey(void *, int, int);
+void sdk_wpa_config_profile(struct sdk_g_ic_st *);
+void sdk_wpa_config_bss(struct sdk_g_ic_st *g_ic, uint8_t (* hwaddr2)[6]);
+void sdk_wpa_config_assoc_ie(int , int16_t *, int32_t);
+void sdk_dhcp_bind_check();
+void sdk_eagle_auth_done();
+void sdk_wpa_neg_complete();
+void sdk_wpa_attach(struct sdk_g_ic_st *);
+
+// wpa.o
+void sdk_wpa_set_profile(uint8_t);
+void sdk_wpa_set_bss(uint8_t *hwaddr1, uint8_t (* hwaddr2)[6], uint8_t, uint8_t, uint8_t *, uint8_t *ssid, int);
+void sdk_eapol_txcb();
+void sdk_wpa_register(int, void *, void *, void *, void *, void *);
+
+// wpas_glue.o
+
+#endif /* _ESPLIBS_LIBWPA_H */

--- a/open_esplibs/libmain/user_interface.c
+++ b/open_esplibs/libmain/user_interface.c
@@ -31,7 +31,6 @@
 #include "espressif/osapi.h"
 #include "espressif/user_interface.h"
 
-#include "sdk_internal.h"
 #include "esplibs/libmain.h"
 #include "esplibs/libpp.h"
 #include "esplibs/libphy.h"
@@ -530,10 +529,10 @@ bool sdk_wifi_station_dhcpc_start(void) {
         return false;
     }
     if (netif && sdk_dhcpc_flag == DHCP_STOPPED) {
-        sdk_info.ipaddr.addr = 0;
-        sdk_info.netmask.addr = 0;
-        sdk_info.gw.addr = 0;
-        netif_set_addr(netif, &sdk_info.ipaddr, &sdk_info.netmask, &sdk_info.gw);
+        sdk_info.sta_ipaddr.addr = 0;
+        sdk_info.sta_netmask.addr = 0;
+        sdk_info.sta_gw.addr = 0;
+        netif_set_addr(netif, &sdk_info.sta_ipaddr, &sdk_info.sta_netmask, &sdk_info.sta_gw);
         if (dhcp_start(netif)) {
             return false;
         }


### PR DESCRIPTION
This update adds some new sdk internal structures and updates the existing ones. The global definitions have been moved into the include/esplibs/ directory and sorted per library and per source object file. These are needed to support sdk code to be submitted and if this could be landed first then it would help split them up and might avoid some merge ordering problems. If this were to move a slot then it might break the code, but it's a small part of what it is to be submitted and some extra checks have been added to the structure layouts to try to detect edit problems.  Checks have also been added for the lwip netif slots offsets known to be used by the sdk binary code which should help other people using esp-open-rtos as a lwip development platform.