### PR TITLE
Use a separate file for the private SSID config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 script:
   - cd ${TRAVIS_BUILD_DIR}
   # Remove ssid_config requirement for examples
-  - sed -i "s%#error%//#error%" include/ssid_config.h
+  - echo -e '#define WIFI_SSID "mywifissid"\n#define WIFI_PASS "my secret password"\n' > include/private_ssid_config.h
   # Don't verbose-build all examples (too much output), only verbose-build errors
   - ( ${MAKE_CMD} ) || ( ${MAKE_CMD} V=1 )
   # build bootloader

--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@ git clone --recursive https://github.com/Superhouse/esp-open-rtos.git
 cd esp-open-rtos
 ```
 
-* To build any examples that use WiFi, edit `include/ssid_config.h` and change the two macro defines:
+* To build any examples that use WiFi, create `include/private_ssid_config.h` defining the two macro defines:
 
 ```c
 #define WIFI_SSID "mywifissid"
 #define WIFI_PASS "my secret password"
 ```
-
-Remove the `#warning` line and follow the git ignore instructions written in the header file to keep your credentials from being pushed to Github.
 
 * Build an example project (found in the 'examples' directory) and flash it to a serial port:
 

--- a/include/.gitignore
+++ b/include/.gitignore
@@ -1,0 +1,1 @@
+private_ssid_config.h

--- a/include/ssid_config.h
+++ b/include/ssid_config.h
@@ -3,29 +3,16 @@
 //
 // We all need to add our personal SSID/password to each ESP project but we
 // do not want that information pushed to Github. This file solves that
-// problem.
+// problem. Create an include/private_ssid_config.h file with the following two
+// definitions uncommented:
 //
-// First tell git to ignore changes to this file:
+// #define WIFI_SSID "mywifissid"
+// #define WIFI_PASS "my secret password"
 //
-// git update-index --assume-unchanged include/ssid_config.h 
-//
-// Then, enter your SSID and passphrase below and it will never be committed
-// to Github.
-//
-// Change password on project basis? Copy the default version this file to your
-// project directory, redo the instructions and you have separate wifi settings
-// for that project.
-// 
-// For reference, see
-//   https://www.kernel.org/pub/software/scm/git/docs/git-update-index.html
-//
-
-#error "You need to enter your wifi credentials in this file and follow the instructions here to keep the password safe from Github commits."
 
 #ifndef __SSID_CONFIG_H__
 #define __SSID_CONFIG_H__
 
-#define WIFI_SSID "mywifissid"
-#define WIFI_PASS "my secret password"
+#include "private_ssid_config.h"
 
 #endif // __SSID_CONFIG_H__


### PR DESCRIPTION
This patch moves the private SSID config to a file not included in the git repo. The current setup is a real foot gun for developer. Non-developers can almost as easily create a separate file as editing the ssid_config.h file. Alternatively a template file could be included. When developers are dealing with many git repo copies and trying to test things, it's just too much of a burden to have to manually config git for the ssid_config.h file, and we need to commit to the master branch and test that so can not deal with this in a local branch. As a developer, don't expect more contributions from me here if this is not fixed.