### PR TITLE
open_esplibs user_interface: source code for functions touching the struct netif.

### DIFF
--- a/include/espressif/esp_system.h
+++ b/include/espressif/esp_system.h
@@ -37,8 +37,8 @@ enum sdk_sleep_type {
     WIFI_SLEEP_LIGHT = 1,
     WIFI_SLEEP_MODEM = 2,
 };
-void sdk_wifi_set_sleep_type(enum sdk_sleep_type);
-enum sdk_sleep_type sdk_wifi_get_sleep_type(enum sdk_sleep_type);
+bool sdk_wifi_set_sleep_type(enum sdk_sleep_type);
+enum sdk_sleep_type sdk_wifi_get_sleep_type(void);
 
 void sdk_system_restore(void);
 void sdk_system_restart(void);


### PR DESCRIPTION
Add source code for functions touching the struct netif to better support lwip development: sdk_wifi_get_ip_info, sdk_wifi_set_ip_info, sdk_wifi_get_macaddr, sdk_wifi_set_macaddr.

Also code for sdk_wifi_station_get_connect_status.

Also code for wifi_get_sleep_type and set_sleep_type, noting wifi_set_sleep_type returns a bool success flag, and implement wifi_get_sleep_type using sdk_pm_get_sleep_type.