### PR TITLE
open_esplibs libnet80211: source code for sdk_wifi_station_start and stop.

### DIFF
--- a/open_esplibs/libnet80211/ieee80211_sta.c
+++ b/open_esplibs/libnet80211/ieee80211_sta.c
@@ -7,5 +7,70 @@
 #if OPEN_LIBNET80211_STA
 // The contents of this file are only built if OPEN_LIBNET80211_STA is set to true
 
+#include <string.h>
+#include "esplibs/libmain.h"
+#include "esplibs/libnet80211.h"
+#include "esplibs/libpp.h"
+#include "esplibs/libwpa.h"
+#include "tcpip.h"
+#include "espressif/esp_sta.h"
+
+
+void sdk_sta_status_set(int status) {
+    struct sdk_g_ic_netif_info *netif_info = sdk_g_ic.v.station_netif_info;
+    uint32_t statusb8 = netif_info->statusb8;
+
+    if (statusb8 == 1 || statusb8 == status) {
+        uint32_t statusb9 = netif_info->statusb9 + 1;
+        netif_info->statusb9 = statusb9;
+        if (statusb9 == 3)
+            netif_info->connect_status = status;
+    } else {
+        netif_info->statusb9 = 0;
+        netif_info->connect_status = 1;
+    }
+
+    netif_info->statusb8 = status;
+
+    return;
+}
+
+bool sdk_wifi_station_start() {
+    struct sdk_g_ic_netif_info *netif_info = sdk_g_ic.v.station_netif_info;
+    if (!netif_info)
+        return 0;
+
+    if (!netif_info->started) {
+        if (!netif_info->netif) {
+            struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
+            netif_info->netif = netif;
+            memcpy(&netif->hwaddr, &sdk_info.sta_mac_addr, 6);
+            netif_add(netif, &sdk_info.sta_ipaddr, &sdk_info.sta_netmask, &sdk_info.sta_gw, netif_info, ethernetif_init, tcpip_input);
+            sdk_wpa_attach(&sdk_g_ic);
+        }
+        sdk_ic_set_vif(0, 1, &sdk_info.sta_mac_addr, 0, 0);
+        netif_info->statusb8 = 0;
+        netif_info->statusb9 = 0;
+        netif_info->started = 1;
+    }
+
+    return 1;
+}
+
+bool sdk_wifi_station_stop() {
+    struct sdk_g_ic_netif_info *netif_info = sdk_g_ic.v.station_netif_info;
+    if (!netif_info)
+        return 0;
+
+    if (netif_info->started) {
+        netif_info->statusb8 = 0;
+        netif_info->statusb9 = 0;
+        sdk_wifi_station_disconnect();
+        sdk_ic_set_vif(0, 0, NULL, 0, 0);
+        netif_info->started = 0;
+    }
+
+    return 1;
+}
 
 #endif /* OPEN_LIBNET80211_STA */


### PR DESCRIPTION
The function sdk_wifi_station_start is one of two paths that allocates a lwip struct netif and also accesses the netif->hwaddr slot so this is required for lwip development.

Also code for sdk_wifi_station_stop and sdk_sta_status_set to better understand the status state.