### PR TITLE
Driver + example for MCP4725 12-bit I2C DAC

### DIFF
--- a/examples/mcp4725_test/Makefile
+++ b/examples/mcp4725_test/Makefile
@@ -1,0 +1,4 @@
+PROGRAM = mcp4725_test
+EXTRA_COMPONENTS = extras/i2c extras/mcp4725
+#ESPBAUD = 460800
+include ../../common.mk

--- a/examples/mcp4725_test/main.c
+++ b/examples/mcp4725_test/main.c
@@ -1,0 +1,66 @@
+/*
+ * Example of using MCP4725 DAC
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2016 Ruslan V. Uss <unclerus@gmail.com>
+ * BSD Licensed as described in the file LICENSE
+ */
+#include <esp/uart.h>
+#include <espressif/esp_common.h>
+#include <i2c/i2c.h>
+#include <mcp4725/mcp4725.h>
+#include <stdio.h>
+
+#include <FreeRTOS.h>
+#include <task.h>
+
+#define SCL_PIN 5
+#define SDA_PIN 4
+#define ADDR MCP4725A0_ADDR0
+#define VDD 3.3
+
+inline static void wait_for_eeprom()
+{
+    while (mcp4725_eeprom_busy(ADDR))
+    {
+        printf("...DAC is busy, waiting...\n");
+        vTaskDelay(1);
+    }
+}
+
+void user_init(void)
+{
+    uart_set_baud(0, 115200);
+    printf("SDK version:%s\n", sdk_system_get_sdk_version());
+
+    i2c_init(SCL_PIN, SDA_PIN);
+
+    // setup EEPROM values
+    if (mcp4725_get_power_mode(ADDR, true) != MCP4725_PM_NORMAL)
+    {
+        printf("DAC was sleeping... Wake up Neo!\n");
+        mcp4725_set_power_mode(ADDR, MCP4725_PM_NORMAL, true);
+        wait_for_eeprom();
+    }
+
+    printf("Set default DAC ouptut value to MAX...\n");
+    mcp4725_set_raw_output(ADDR, MCP4725_MAX_VALUE, true);
+    wait_for_eeprom();
+
+    printf("And now default DAC output value is 0x%03x\n", mcp4725_get_raw_output(ADDR, true));
+
+    printf("Now let's generate the sawtooth wave in slow manner\n");
+
+    float vout = 0;
+    while (true)
+    {
+        vout += 0.1;
+        if (vout > VDD) vout = 0;
+
+        printf("Vout: %.02f\n", vout);
+        mcp4725_set_voltage(ADDR, VDD, vout, false);
+
+        // It will be very low freq wave
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+    }
+}

--- a/extras/mcp4725/component.mk
+++ b/extras/mcp4725/component.mk
@@ -1,0 +1,9 @@
+# Component makefile for extras/mcp4725
+
+# expected anyone using this driver includes it as 'mcp4725/mcp4725.h'
+INC_DIRS += $(mcp4725_ROOT)..
+
+# args for passing into compile rule generation
+mcp4725_SRC_DIR = $(mcp4725_ROOT)
+
+$(eval $(call component_compile_rules,mcp4725))

--- a/extras/mcp4725/mcp4725.c
+++ b/extras/mcp4725/mcp4725.c
@@ -1,0 +1,71 @@
+/*
+ * Driver for 12-bit DAC MCP4725
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2016 Ruslan V. Uss <unclerus@gmail.com>
+ * BSD Licensed as described in the file LICENSE
+ */
+#include "mcp4725.h"
+#include <i2c/i2c.h>
+
+#define CMD_DAC    0x40
+#define CMD_EEPROM 0x60
+#define BIT_READY  0x80
+
+static void read_data(uint8_t addr, uint8_t *buf, uint8_t size)
+{
+    i2c_start();
+    i2c_write(addr << 1 | 1);
+    while (size--)
+        *(buf++) = i2c_read(!size);
+    i2c_stop();
+}
+
+bool mcp4725_eeprom_busy(uint8_t addr)
+{
+    uint8_t res;
+    read_data(addr, &res, 1);
+
+    return !(res & BIT_READY);
+}
+
+mcp4725_power_mode_t mcp4725_get_power_mode(uint8_t addr, bool eeprom)
+{
+    uint8_t buf[4];
+    read_data(addr, buf, eeprom ? 4 : 1);
+
+    return (eeprom ? buf[3] >> 5 : buf[0] >> 1) & 0x03;
+}
+
+void mcp4725_set_power_mode(uint8_t addr, mcp4725_power_mode_t mode, bool eeprom)
+{
+    uint16_t value = mcp4725_get_raw_output(addr, eeprom);
+    uint8_t data[] = {
+        (eeprom ? CMD_EEPROM : CMD_DAC) | ((uint8_t)mode << 1),
+        value >> 4,
+        value << 4
+    };
+    i2c_slave_write(addr, data, 3);
+}
+
+uint16_t mcp4725_get_raw_output(uint8_t addr, bool eeprom)
+{
+    uint8_t buf[5];
+    read_data(addr, buf, eeprom ? 5 : 3);
+
+    return eeprom
+        ? ((uint16_t)(buf[3] & 0x0f) << 8) | buf[4]
+        : ((uint16_t)buf[0] << 4) | (buf[1] >> 4);
+}
+
+void mcp4725_set_raw_output(uint8_t addr, uint16_t value, bool eeprom)
+{
+    uint8_t data[] = {
+        (eeprom ? CMD_EEPROM : CMD_DAC),
+        value >> 4,
+        value << 4
+    };
+    i2c_slave_write(addr, data, 3);
+}
+
+

--- a/extras/mcp4725/mcp4725.h
+++ b/extras/mcp4725/mcp4725.h
@@ -1,0 +1,106 @@
+/*
+ * Driver for 12-bit DAC MCP4725
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2016 Ruslan V. Uss <unclerus@gmail.com>
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _EXTRAS_MCP4725_H_
+#define _EXTRAS_MCP4725_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define MCP4725A0_ADDR0 0x60
+#define MCP4725A0_ADDR1 0x61
+#define MCP4725A1_ADDR0 0x62
+#define MCP4725A1_ADDR1 0x63
+#define MCP4725A2_ADDR0 0x64
+#define MCP4725A2_ADDR1 0x65
+
+#define MCP4725_MAX_VALUE 0x0fff
+
+/**
+ * Power mode, see datasheet
+ */
+typedef enum
+{
+    MCP4725_PM_NORMAL = 0,   //!< Normal mode
+    MCP4725_PM_PD_1K,        //!< Power down, 1kOhm resistor to ground
+    MCP4725_PM_PD_100K,      //!< Power down, 100kOhm resistor to ground
+    MCP4725_PM_PD_500K,      //!< Power down, 500kOhm resistor to ground
+} mcp4725_power_mode_t;
+
+/**
+ * Get device EEPROM status
+ * @param addr Device address
+ * @return true when EEPROM is busy
+ */
+bool mcp4725_eeprom_busy(uint8_t addr);
+
+/**
+ * Get power mode
+ * @param addr Device address
+ * @param eeprom Read power mode from EEPROM if true
+ * @return Power mode
+ */
+mcp4725_power_mode_t mcp4725_get_power_mode(uint8_t addr, bool eeprom);
+
+/**
+ * Set power mode
+ * @param addr Device address
+ * @param mode Power mode
+ * @param eeprom Store mode to device EEPROM if true
+ */
+void mcp4725_set_power_mode(uint8_t addr, mcp4725_power_mode_t mode, bool eeprom);
+
+/**
+ * Get current DAC value
+ * @param addr Device address
+ * @param eeprom Read value from device EEPROM if true
+ * @return Raw output value, 0..4095
+ */
+uint16_t mcp4725_get_raw_output(uint8_t addr, bool eeprom);
+
+/**
+ * Set DAC output value
+ * @param addr Device address
+ * @param value Raw output value, 0..4095
+ * @param eeprom Store value to device EEPROM if true
+ */
+void mcp4725_set_raw_output(uint8_t addr, uint16_t value, bool eeprom);
+
+/**
+ * Get current DAC output voltage
+ * @param addr Device address
+ * @param vdd Device operating voltage, volts
+ * @param eeprom Read voltage from device EEPROM if true
+ * @return Current output voltage, volts
+ */
+inline float mcp4725_get_voltage(uint8_t addr, float vdd, bool eeprom)
+{
+    return vdd / MCP4725_MAX_VALUE * mcp4725_get_raw_output(addr, eeprom);
+}
+
+/**
+ * Set DAC output voltage
+ * @param addr Device address
+ * @param vdd Device operating voltage, volts
+ * @param value Output value, volts
+ * @param eeprom Store value to device EEPROM if true
+ */
+inline void mcp4725_set_voltage(uint8_t addr, float vdd, float value, bool eeprom)
+{
+    mcp4725_set_raw_output(addr, MCP4725_MAX_VALUE / vdd * value, eeprom);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _EXTRAS_MCP4725_H_ */


### PR DESCRIPTION
The MCP4725 is a low-power, high accuracy, single channel, 12-bit buffered voltage output Digital-to-Ana-
log Convertor (DAC) with non-volatile memory (EEPROM). Its on-board precision output amplifier allows it to achieve rail-to-rail analog output swing.
