### PR TITLE
Fixes SPI Bug(s)

### DIFF
--- a/core/esp_spi.c
+++ b/core/esp_spi.c
@@ -224,20 +224,20 @@ uint32_t spi_transfer_32(uint8_t bus, uint32_t data)
 static void _rearm_extras_bit(uint8_t bus, bool arm) {
 
     if(!_minimal_pins[bus]) return ;
-    static uint8_t status = 0 ;
+    static uint8_t status[2] ;
 
     if (arm)
     {
-        if (status & (0x01<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_ADDR) ;
-        if (status & (0x02<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_COMMAND) ;
-        if (status & (0x04<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_DUMMY | SPI_USER0_MISO);
-        status &= ~(0x0F<<(4*bus));
+        if (status[bus] & 0x01) SPI(bus).USER0 |= (SPI_USER0_ADDR) ;
+        if (status[bus] & 0x02) SPI(bus).USER0 |= (SPI_USER0_COMMAND) ;
+        if (status[bus] & 0x04) SPI(bus).USER0 |= (SPI_USER0_DUMMY | SPI_USER0_MISO);
+        status[bus] = 0;
     }
     else
     {
-        if (SPI(bus).USER0 & SPI_USER0_ADDR) { SPI(bus).USER0 &= ~(SPI_USER0_ADDR) ; status |= 0x01<<(4*bus) ; }
-        if (SPI(bus).USER0 & SPI_USER0_COMMAND) { SPI(bus).USER0 &= ~(SPI_USER0_COMMAND) ; status |= 0x02<<(4*bus) ; }
-        if (SPI(bus).USER0 & SPI_USER0_DUMMY) { SPI(bus).USER0 &= ~(SPI_USER0_DUMMY | SPI_USER0_MISO); status |= 0x04<<(4*bus) ; }
+        if (SPI(bus).USER0 & SPI_USER0_ADDR) { SPI(bus).USER0 &= ~(SPI_USER0_ADDR) ; status[bus] |= 0x01 ; }
+        if (SPI(bus).USER0 & SPI_USER0_COMMAND) { SPI(bus).USER0 &= ~(SPI_USER0_COMMAND) ; status[bus] |= 0x02 ; }
+        if (SPI(bus).USER0 & SPI_USER0_DUMMY) { SPI(bus).USER0 &= ~(SPI_USER0_DUMMY | SPI_USER0_MISO); status[bus] |= 0x04 ; }
     }
 }
 

--- a/core/esp_spi.c
+++ b/core/esp_spi.c
@@ -228,16 +228,16 @@ static void _rearm_extras_bit(uint8_t bus, bool arm) {
 
     if (arm)
     {
-        if (status & 0x01) SPI(bus).USER0 |= (SPI_USER0_ADDR) ;
-        if (status & 0x02) SPI(bus).USER0 |= (SPI_USER0_COMMAND) ;
-        if (status & 0x04) SPI(bus).USER0 |= (SPI_USER0_DUMMY | SPI_USER0_MISO);
-        status = 0 ;
+        if (status & (0x01<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_ADDR) ;
+        if (status & (0x02<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_COMMAND) ;
+        if (status & (0x04<<(4*bus))) SPI(bus).USER0 |= (SPI_USER0_DUMMY | SPI_USER0_MISO);
+        status &= ~(0x0F<<(4*bus));
     }
     else
     {
-        if (SPI(bus).USER0 & SPI_USER0_ADDR) { SPI(bus).USER0 &= ~(SPI_USER0_ADDR) ; status |= 1 ; }
-        if (SPI(bus).USER0 & SPI_USER0_COMMAND) { SPI(bus).USER0 &= ~(SPI_USER0_COMMAND) ; status |= 2 ; }
-        if (SPI(bus).USER0 & SPI_USER0_DUMMY) { SPI(bus).USER0 &= ~(SPI_USER0_DUMMY | SPI_USER0_MISO); status |= 4 ; }
+        if (SPI(bus).USER0 & SPI_USER0_ADDR) { SPI(bus).USER0 &= ~(SPI_USER0_ADDR) ; status |= 0x01<<(4*bus) ; }
+        if (SPI(bus).USER0 & SPI_USER0_COMMAND) { SPI(bus).USER0 &= ~(SPI_USER0_COMMAND) ; status |= 0x02<<(4*bus) ; }
+        if (SPI(bus).USER0 & SPI_USER0_DUMMY) { SPI(bus).USER0 &= ~(SPI_USER0_DUMMY | SPI_USER0_MISO); status |= 0x04<<(4*bus) ; }
     }
 }
 

--- a/core/include/esp/spi.h
+++ b/core/include/esp/spi.h
@@ -317,9 +317,9 @@ static inline void spi_set_command(uint8_t bus,uint8_t bits, uint16_t data)
 static inline void spi_set_address(uint8_t bus,uint8_t bits, uint32_t data)
 {
     if(!bits) return ;
-    SPI(bus).USER1 = SET_FIELD(SPI(bus).USER1, SPI_USER1_ADDR_BITLEN, --bits);
     SPI(bus).USER0 |= SPI_USER0_ADDR ; //enable ADDRess function in SPI module
     SPI(bus).ADDR = data<<(32-bits) ; //align address data to high bits
+    SPI(bus).USER1 = SET_FIELD(SPI(bus).USER1, SPI_USER1_ADDR_BITLEN, --bits);
 }
 
 /**


### PR DESCRIPTION
Hi i discovered 2 bug with the new SPI API, one is fixed. I still think the way for resolve the second.
First Bug:
Wrong address was set, just swap instructions order to solve it.

Second Bug:
It is a special case that the API does not take into account.
If CS is software , If Address/command/dummy is set and if data transfered is greater than SPI_BUFFER, it will send a second time (or more) addr/dummy/cmd as data :(.

I have some idea to solve it.
1 - If addr/dummy/cmd set, limit transfert to BUF SIZE  ( not sure if it is a good idea )
2 - add extras instructions to clear and  rearm dummy/addr/cmd.

But maybe an other way to solve it is better, some suggestion ? 