### PR TITLE
httpd: support for large WebSocket frames

### DIFF
--- a/extras/httpd/httpd.h
+++ b/extras/httpd/httpd.h
@@ -244,7 +244,7 @@ typedef void (*tWsOpenHandler)(struct tcp_pcb *pcb, const char *uri);
  *
  * @param pcb tcp_pcb to send.
  * @param data data to send.
- * @param len data length (should not exceed 125).
+ * @param len data length.
  * @param mode WS_TEXT_MODE or WS_BIN_MODE.
  * @return ERR_OK if write succeeded.
  */

--- a/extras/httpd/readme.txt
+++ b/extras/httpd/readme.txt
@@ -1,4 +1,11 @@
-Maintained by lujji (https://github.com/lujji/esp-httpd).
+This is a basic HTTP server with WebSockets based on httpd from LwIP.
 
-Note: this module expects your project to provide "fsdata.c" created with "makefsdata" utility.
+WebSockets implementation supports binary and text modes. Multiple sockets are supported. Continuation frames are not implemented.
+By default, a WebSocket is closed after 20 seconds of inactivity to conserve memory. This behavior can be changed by overriding `WS_TIMEOUT` option.
+
+To enable debugging extra flags `-DLWIP_DEBUG=1 -DHTTPD_DEBUG=LWIP_DBG_ON` should be passed at compile-time.
+
+This module expects your project to provide "fsdata.c" created with "makefsdata" utility.
 See examples/http_server.
+
+Maintained by lujji (https://github.com/lujji/esp-httpd).


### PR DESCRIPTION
I wanted to merge yesterday, but was a bit late.

Changes:
- support for WebSocket frames >125 bytes
- fixed minor issue with timeout
- updated readme

I'm not planning any major changes so it's safe to merge.