### PR TITLE
Added sdk_system_get_netif

### DIFF
--- a/include/espressif/esp_system.h
+++ b/include/espressif/esp_system.h
@@ -28,6 +28,8 @@ struct sdk_rst_info{
 	uint32_t rtn_addr;
 };
 
+struct netif *sdk_system_get_netif(uint32_t mode);
+
 struct sdk_rst_info* sdk_system_get_rst_info(void);
 
 const char* sdk_system_get_sdk_version(void);

--- a/open_esplibs/libmain/user_interface.c
+++ b/open_esplibs/libmain/user_interface.c
@@ -517,6 +517,10 @@ struct sdk_rst_info *sdk_system_get_rst_info(void) {
     return &sdk_rst_if;
 }
 
+struct netif *sdk_system_get_netif(uint32_t mode) {
+    return _get_netif(mode);
+}
+
 static struct netif *_get_netif(uint32_t mode) {
     struct sdk_g_ic_netif_info *info;
 


### PR DESCRIPTION
I started playing with multicast and following [this tread](http://lwip.100.n7.nabble.com/Multicast-Example-td10415.html) I realized the `netif` struct needed to be exported from user_interface.c. There was a static function `_get_netif` that I exported as `sdk_system_get_netif` (to follow the naming standard of user_interface.c) . A function prototype is available in esp_system.h.