### PR TITLE
extras/sntp: fix an off-by-one bug in sntp_set_servers()

### DIFF
--- a/extras/sntp/sntp.c
+++ b/extras/sntp/sntp.c
@@ -730,10 +730,8 @@ int sntp_set_servers(char *server_url[], int num_servers)
 
   /* Allocate memory and copy servers */
   for (i = 0; i < num_servers; i++) {
-    sntp_server_addresses[i] = malloc(strlen(server_url[i]));
-    if (sntp_server_addresses[i]) {
-   	  strcpy(sntp_server_addresses[i], server_url[i]);
-    } else {
+    sntp_server_addresses[i] = strdup(server_url[i]);
+    if (!sntp_server_addresses[i]) {
 	  sntp_num_servers = i;
       return -2;
     }


### PR DESCRIPTION
The function sntp_set_servers() duplicates the strings supplied in the
server_url[] array into new strings but forgets to allocate the extra
byte needed for the \0 terminator for each string.

Fix the problem by using strdup(), which allocates the right amount of
memory and copies the string at once.

---
I also wonder why it's allocating heap space instead of just copying the pointers, which seems more efficient to me.