### PR TITLE
Give FreeRTOS Hooks weak linkage

### DIFF
--- a/core/app_main.c
+++ b/core/app_main.c
@@ -236,12 +236,12 @@ void IRAM vApplicationStackOverflowHook(TaskHandle_t task, char *task_name) {
 }
 
 // .text+0x3d8
-void IRAM vApplicationIdleHook(void) {
+void __attribute__((weak)) IRAM vApplicationIdleHook(void) {
     printf("idle %u\n", WDEV.SYS_TIME);
 }
 
 // .text+0x404
-void IRAM vApplicationTickHook(void) {
+void __attribute__((weak)) IRAM vApplicationTickHook(void) {
     printf("tick %u\n", WDEV.SYS_TIME);
 }
 

--- a/examples/tick_idle_hooks/FreeRTOSConfig.h
+++ b/examples/tick_idle_hooks/FreeRTOSConfig.h
@@ -1,0 +1,10 @@
+/**
+
+ Configuration overrides for FreeRTOS.
+
+**/
+
+#define configUSE_IDLE_HOOK 1
+#define configUSE_TICK_HOOK 1
+
+#include_next "FreeRTOSConfig.h"

--- a/examples/tick_idle_hooks/Makefile
+++ b/examples/tick_idle_hooks/Makefile
@@ -1,0 +1,3 @@
+# Simple makefile for simple example
+PROGRAM=simple
+include ../../common.mk

--- a/examples/tick_idle_hooks/hooks_example.c
+++ b/examples/tick_idle_hooks/hooks_example.c
@@ -1,0 +1,56 @@
+/* Very basic example that just demonstrates we can run at all!
+ */
+#include "espressif/esp_common.h"
+#include "esp/uart.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+
+void vApplicationIdleHook(void) 
+{
+    // Go to sleep; either deeply (waiting for an event to wake)
+    // or light, allowing FreeRTOS ticks to wake
+    sdk_wifi_set_sleep_type(WIFI_SLEEP_MODEM);
+}
+
+void vApplicationTickHook(void) 
+{
+  // Called every tick
+}
+
+void task1(void *pvParameters)
+{
+    QueueHandle_t *queue = (QueueHandle_t *)pvParameters;
+    printf("Hello from task1!\r\n");
+    uint32_t count = 0;
+    while(1) {
+        vTaskDelay(100);
+        xQueueSend(*queue, &count, 0);
+        count++;
+    }
+}
+
+void task2(void *pvParameters)
+{
+    printf("Hello from task 2!\r\n");
+    QueueHandle_t *queue = (QueueHandle_t *)pvParameters;
+    while(1) {
+        uint32_t count;
+        if(xQueueReceive(*queue, &count, 1000)) {
+            printf("Got %u\n", count);
+        } else {
+            printf("No msg :(\n");
+        }
+    }
+}
+
+static QueueHandle_t mainqueue;
+
+void user_init(void)
+{
+    uart_set_baud(0, 115200);
+    printf("SDK version:%s\n", sdk_system_get_sdk_version());
+    mainqueue = xQueueCreate(10, sizeof(uint32_t));
+    xTaskCreate(task1, "tsk1", 256, &mainqueue, 2, NULL);
+    xTaskCreate(task2, "tsk2", 256, &mainqueue, 2, NULL);
+}


### PR DESCRIPTION
Sometimes it's nice to have access to the FreeRTOS tick and idle hooks. This pull request enables that by allowing user code to override the default implementations provided in `app_main.c`.

To use this, include a file in your project called `FreeRTOSConfig.h` with (at least) the contents shown in the example. You may need to `make clean` to cause FreeRTOS to be rebuilt. Overrides for `vApplicationIdleHook` and `vApplicationTickHook` can now be provided.

**One Caveat** with this pull request specifically is that I do not yet fully understand the sleep functions provided in the SDK. I believe that if `WIFI_SLEEP_LIGHT` is passed in the idle hook, the wifi radio will sleep if connected (or the call will fail if not connected). Either way, the call is noisy and that makes timing and whether the sleep call is working at all difficult to discern. If it's easier to just pull out the example that's fine too.
