### PR TITLE
add USER_LIBS to common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ PROGRAM_DIR := $(dir $(firstword $(MAKEFILE_LIST)))
 
 # derive various parts of compiler/linker arguments
 SDK_LIB_ARGS  = $(addprefix -l,$(SDK_LIBS))
-LIB_ARGS      = $(addprefix -l,$(LIBS))
+LIB_ARGS      = $(addprefix -l,$(LIBS) $(USER_LIBS))
 PROGRAM_OUT   = $(BUILD_DIR)$(PROGRAM).out
 LDFLAGS      += $(addprefix -T,$(LINKER_SCRIPTS))
 


### PR DESCRIPTION
This is to solve issue #376; libraries can now be added to a project with the addition of `USER_LIBS=...` to the Makefile without removing those from parameters.mk.