### PR TITLE
travis: update the esp-open-sdk version used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: false
 env:
   # Target commit for https://github.com/pfalcon/esp-open-sdk/
-  OPENSDK_COMMIT=a48b12f
+  OPENSDK_COMMIT=b069537
   CROSS_ROOT="${HOME}/toolchain-${OPENSDK_COMMIT}"
   CROSS_BINDIR="${CROSS_ROOT}/bin"
   CROSS="ccache xtensa-lx106-elf-"
@@ -32,6 +32,7 @@ addons:
     - python-serial
     - sed
     - git
+    - help2man
     - vim-common
 
 before_install:


### PR DESCRIPTION
Seeing odd build failures in lwip v2 with the old version of the tools chain used for travis, but it builds fine locally with more recent versions so give that a try.