### PR TITLE
MQTT ignores too many handlers registered

### DIFF
--- a/extras/paho_mqtt_c/MQTTClient.c
+++ b/extras/paho_mqtt_c/MQTTClient.c
@@ -424,6 +424,8 @@ int  mqtt_subscribe(mqtt_client_t* c, const char* topic, enum mqtt_qos qos, mqtt
         if (rc != 0x80)
         {
             int i;
+            
+            rc = MQTT_FAILURE;
             for (i = 0; i < MQTT_MAX_MESSAGE_HANDLERS; ++i)
             {
                 if (c->messageHandlers[i].topicFilter == 0)


### PR DESCRIPTION
On MQTTClient.c function mqtt_subscribe, if more than MQTT_MAX_MESSAGE_HANDLERS are registered, the variable rc receives the value of grantedQoS.

If grantedQoS = 0, and all handlers are already occupied, it goes on and returns 0 to the caller.