### PR TITLE
Mqtt timer not sleeping

### DIFF
--- a/extras/paho_mqtt_c/MQTTESP8266.c
+++ b/extras/paho_mqtt_c/MQTTESP8266.c
@@ -32,7 +32,7 @@ char  mqtt_timer_expired(mqtt_timer_t* timer)
 {
     TickType_t now = xTaskGetTickCount();
     int32_t left = timer->end_time - now;
-    return (left < 0);
+    return (left <= 0);
 }
 
 

--- a/extras/paho_mqtt_c/MQTTESP8266.c
+++ b/extras/paho_mqtt_c/MQTTESP8266.c
@@ -53,7 +53,7 @@ int  mqtt_timer_left_ms(mqtt_timer_t* timer)
 {
     TickType_t now = xTaskGetTickCount();
     int32_t left = timer->end_time - now;
-    return (left < 0) ? 0 : left / portTICK_PERIOD_MS;
+    return (left < 0) ? 0 : left * portTICK_PERIOD_MS;
 }
 
 
@@ -72,9 +72,8 @@ int  mqtt_esp_read(mqtt_network_t* n, unsigned char* buffer, int len, int timeou
     int rcvd = 0;
     FD_ZERO(&fdset);
     FD_SET(n->my_socket, &fdset);
-    // It seems tv_sec actually means FreeRTOS tick
-    tv.tv_sec = timeout_ms / portTICK_PERIOD_MS;
-    tv.tv_usec = 0;
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
     rc = select(n->my_socket + 1, &fdset, 0, 0, &tv);
     if ((rc > 0) && (FD_ISSET(n->my_socket, &fdset)))
     {
@@ -97,9 +96,8 @@ int  mqtt_esp_write(mqtt_network_t* n, unsigned char* buffer, int len, int timeo
 
     FD_ZERO(&fdset);
     FD_SET(n->my_socket, &fdset);
-    // It seems tv_sec actually means FreeRTOS tick
-    tv.tv_sec = timeout_ms / portTICK_PERIOD_MS;
-    tv.tv_usec = 0;
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
     rc = select(n->my_socket + 1, 0, &fdset, 0, &tv);
     if ((rc > 0) && (FD_ISSET(n->my_socket, &fdset)))
     {


### PR DESCRIPTION
Some timing functions of the ESP82668's MQTT client port seems to be using incorrect values. That was causing tasks to busy wait for a packet inside the cycle function, increasing power usage and not letting lower priority tasks execute.