### PR TITLE
Use hwrand for the sdk uses of rand, in particular with the NMI.

### DIFF
--- a/core/esp_hwrand.c
+++ b/core/esp_hwrand.c
@@ -10,8 +10,13 @@
 #include <esp/wdev_regs.h>
 #include <string.h>
 
-/* Return a random 32-bit number */
-uint32_t hwrand(void)
+/* Return a random 32-bit number.
+ *
+ * This is also used as a substitute for rand() called from
+ * lmac.a:sdk_lmacTxFrame to avoid touching the newlib reent structures within
+ * the NMI and the NMI code needs to be in IRAM.
+ */
+uint32_t IRAM hwrand(void)
 {
     return WDEV.HWRNG;
 }

--- a/lib/allsymbols.rename
+++ b/lib/allsymbols.rename
@@ -419,6 +419,7 @@ ram_set_txbb_atten sdk_ram_set_txbb_atten
 ram_start_noisefloor sdk_ram_start_noisefloor
 ram_tx_mac_disable sdk_ram_tx_mac_disable
 ram_tx_mac_enable sdk_ram_tx_mac_enable
+rand hwrand
 rc4_skip sdk_rc4_skip
 rcAttach sdk_rcAttach
 rc_cal sdk_rc_cal


### PR DESCRIPTION
The fiq NMI calls rand() from lmac:lmac.a:sdk_lmacTxFrame and the NMI must not touch the newlib reent structure or enter critical regions etc, so just use the simple and safe hwrand implementation as a
substitute.