### PR TITLE
Include python3-serial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
     - libncurses5-dev
     - libexpat1-dev
     - python
-    - python-serial
+    - python3-serial
     - sed
     - git
     - help2man


### PR DESCRIPTION
Seem that including python-serial no longer works, so try python3-serial?