### PR TITLE
sysparam: reserve one more flash sector before placing the sysparams

### DIFF
--- a/core/app_main.c
+++ b/core/app_main.c
@@ -214,8 +214,8 @@ void IRAM sdk_user_start(void) {
     memcpy(&sdk_g_ic.s, buf32, sizeof(struct sdk_g_ic_saved_st));
 
     // By default, put the sysparam region just below the config sectors at the
-    // top of the flash space
-    sysparam_addr = flash_size - (4 + DEFAULT_SYSPARAM_SECTORS) * sdk_flashchip.sector_size;
+    // top of the flash space, and allowing one extra sector spare.
+    sysparam_addr = flash_size - (5 + DEFAULT_SYSPARAM_SECTORS) * sdk_flashchip.sector_size;
     status = sysparam_init(sysparam_addr, flash_size);
     if (status == SYSPARAM_NOTFOUND) {
         status = sysparam_create_area(sysparam_addr, DEFAULT_SYSPARAM_SECTORS, false);

--- a/examples/sysparam_editor/Makefile
+++ b/examples/sysparam_editor/Makefile
@@ -8,7 +8,7 @@ include ../../common.mk
 # `make dump-flash` can be used to view the current contents of the sysparam
 # regions in flash.
 dump-flash:
-	esptool.py read_flash 0x1f8000 8192 r1.bin
+	esptool.py read_flash 0x1f7000 8192 r1.bin
 	hexdump -C r1.bin
-	esptool.py read_flash 0x1fa000 8192 r2.bin
+	esptool.py read_flash 0x1f9000 8192 r2.bin
 	hexdump -C r2.bin

--- a/examples/sysparam_editor/sysparam_editor.c
+++ b/examples/sysparam_editor/sysparam_editor.c
@@ -173,7 +173,7 @@ void sysparam_editor_task(void *pvParameters) {
         // stuff, so if the user uses this utility to reformat it, it will put
         // it somewhere the system will find it later
         num_sectors = DEFAULT_SYSPARAM_SECTORS;
-        base_addr = sdk_flashchip.chip_size - (4 + num_sectors) * sdk_flashchip.sector_size;
+        base_addr = sdk_flashchip.chip_size - (5 + num_sectors) * sdk_flashchip.sector_size;
     }
     while (true) {
         printf("==> ");
@@ -245,6 +245,8 @@ void sysparam_editor_task(void *pvParameters) {
 void user_init(void)
 {
     uart_set_baud(0, 115200);
+
+    sdk_wifi_set_opmode(NULL_MODE);
 
     xTaskCreate(sysparam_editor_task, "sysparam_editor_task", 512, NULL, 2, NULL);
 }


### PR DESCRIPTION
This is to help work with recent SDKs that add a RF cal sector by
default in the fifth last sector - just so the sysparam sectors do not
jump around when using different SDK versions.