### PR TITLE
i2c: remove wip 400k define

### DIFF
--- a/extras/i2c/i2c.h
+++ b/extras/i2c/i2c.h
@@ -36,8 +36,6 @@ extern "C" {
 #endif
 
 
-#define I2C_FREQUENCY_400K true  // for test WIP
-
 /*
  *  Some bit can be transmit slower.
  *  Selected frequency fix the speed of a bit transmission


### PR DESCRIPTION
Looks like this was test wip code that should not have been included. Want to be able to set the i2c per-project rather than having to patch the driver.

@Zaltora What do you think about this change?

Did not check if some examples depended on a higher speed?
