### PR TITLE
httpd: add missing typedef

### DIFF
--- a/extras/httpd/httpd.h
+++ b/extras/httpd/httpd.h
@@ -231,7 +231,7 @@ void httpd_post_data_recved(void *connection, u16_t recved_len);
 
 #endif /* LWIP_HTTPD_SUPPORT_POST */
 
-enum {
+typedef enum {
   WS_TEXT_MODE = 0x01,
   WS_BIN_MODE  = 0x02,
 } WS_MODE;


### PR DESCRIPTION
Add a missing `typedef` to the `httpd.h` header. Before, the header would define a _variable_ `WS_MODE` which caused linking errors when the header was included in multiple translation units. Now `WS_MODE` is a type alias which was the original intent according to my best understanding.