### PR TITLE
Add a hook for a user defined exception handler

### DIFF
--- a/core/include/user_exception.h
+++ b/core/include/user_exception.h
@@ -1,0 +1,9 @@
+/* Allows the user to set their own exception handler. */
+
+#ifndef _USER_EXCEPTION_H
+#define _USER_EXCEPTION_H
+
+void set_user_exception_handler(void (*fn)(void));
+
+#endif
+


### PR DESCRIPTION
If the software crashes, it is essential in some applications like robotics to e.g. shut down motors for safety. This PR adds an API for the user to add their own exception handler.