### PR TITLE
Added fflush for examples/terminal echo

### DIFF
--- a/examples/terminal/terminal.c
+++ b/examples/terminal/terminal.c
@@ -94,18 +94,23 @@ static void gpiomon()
     int i = 0;
     printf("\n\n\nWelcome to gpiomon. Type 'help<enter>' for, well, help\n");
     printf("%% ");
+    fflush(stdout); // stdout is line buffered
     while(1) {
         if (read(0, (void*)&ch, 1)) { // 0 is stdin
             printf("%c", ch);
+            fflush(stdout);
             if (ch == '\n' || ch == '\r') {
                 cmd[i] = 0;
                 i = 0;
                 printf("\n");
                 handle_command((char*) cmd);
                 printf("%% ");
+                fflush(stdout);
             } else {
                 if (i < sizeof(cmd)) cmd[i++] = ch;
             }
+        } else {
+            printf("You will never see this print as read(...) is blocking\n");
         }
     }
 }


### PR DESCRIPTION
As the terminal example was meant to echo characters typed I added fflush since the line buffering policy has changed.

While on the topic, should we make IRQ driven stdin standard (which would fix #454)?