### PR TITLE
lwip: define LWIP_POSIX_SOCKETS_IO_NAMES as zero

### DIFF
--- a/examples/http_get/http_get.c
+++ b/examples/http_get/http_get.c
@@ -7,6 +7,7 @@
 #include "espressif/esp_common.h"
 #include "esp/uart.h"
 
+#include <unistd.h>
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/examples/http_get_bearssl/http_get_bearssl.c
+++ b/examples/http_get_bearssl/http_get_bearssl.c
@@ -13,6 +13,7 @@
 #include "esp/uart.h"
 #include "esp/hwrand.h"
 
+#include <unistd.h>
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/examples/tls_server_bearssl/tls_server_bearssl.c
+++ b/examples/tls_server_bearssl/tls_server_bearssl.c
@@ -19,6 +19,7 @@
 #include "esp/uart.h"
 #include "esp/hwrand.h"
 
+#include <unistd.h>
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/extras/mbedtls/net_lwip.c
+++ b/extras/mbedtls/net_lwip.c
@@ -21,6 +21,7 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+#include <fcntl.h>
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/extras/paho_mqtt_c/MQTTESP8266.c
+++ b/extras/paho_mqtt_c/MQTTESP8266.c
@@ -20,6 +20,7 @@
   */
 
 #include <espressif/esp_common.h>
+#include <unistd.h>
 #include <lwip/sockets.h>
 #include <lwip/inet.h>
 #include <lwip/netdb.h>

--- a/extras/spiffs/esp_spiffs.c
+++ b/extras/spiffs/esp_spiffs.c
@@ -149,7 +149,8 @@ int _open_r(struct _reent *r, const char *pathname, int flags, int mode)
     return SPIFFS_open(&fs, pathname, spiffs_flags, mode);
 }
 
-int _close_r(struct _reent *r, int fd)
+// This implementation replaces implementation in core/newlib_syscals.c
+int _close_filesystem_r(struct _reent *r, int fd)
 {
     return SPIFFS_close(&fs, (spiffs_file)fd);
 }

--- a/extras/spiffs/spiffs_config.h
+++ b/extras/spiffs/spiffs_config.h
@@ -198,7 +198,15 @@ typedef unsigned char u8_t;
 // NB: This adds config field fh_ix_offset in the configuration struct when
 // mounting, which must be defined.
 #ifndef SPIFFS_FILEHDL_OFFSET
-#define SPIFFS_FILEHDL_OFFSET                 1
+#define SPIFFS_FILEHDL_OFFSET                 17
+// Not ideal having to use a literal above, which is necessary because this file
+// is also included by tools that run on the host, but at least do some checks
+// when building the target code.
+#ifdef LWIP_SOCKET_OFFSET
+#if SPIFFS_FILEHDL_OFFSET < (LWIP_SOCKET_OFFSET + MEMP_NUM_NETCONN)
+#error SPIFFS_FILEHDL_OFFSET clashes with lwip sockets range.
+#endif
+#endif
 #endif
 
 // Enable this to compile a read only version of spiffs.

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include <espressif/esp_common.h>
 #include <espressif/user_interface.h>
@@ -1722,9 +1723,9 @@ static void dns_task(void *pvParameters)
 
     const struct ifreq ifreq0 = { "en0" };
     const struct ifreq ifreq1 = { "en1" };
-    lwip_setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
-                    sdk_wifi_get_opmode() == STATIONAP_MODE ? &ifreq1 : &ifreq0,
-                    sizeof(ifreq0));
+    setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
+               sdk_wifi_get_opmode() == STATIONAP_MODE ? &ifreq1 : &ifreq0,
+               sizeof(ifreq0));
 
     for (;;) {
         char buffer[96];

--- a/lwip/include/arch/cc.h
+++ b/lwip/include/arch/cc.h
@@ -39,6 +39,7 @@
 #include <sys/time.h>
 #include <sys/errno.h>
 #include <esp/hwrand.h>
+#include <fcntl.h>
 
 struct ip4_addr;
 struct esf_buf;

--- a/lwip/include/lwipopts.h
+++ b/lwip/include/lwipopts.h
@@ -144,6 +144,15 @@
    ------------------------------------------------
 */
 
+/**
+ * MEMP_NUM_NETCONN: the number of struct netconns.
+ * (only needed if you use the sequential API, like api_lib.c)
+ * This also sets the number of lwip socket descriptors.
+ */
+#ifndef MEMP_NUM_NETCONN
+#define MEMP_NUM_NETCONN                12
+#endif
+
 /*
    --------------------------------
    ---------- ARP options -------
@@ -549,6 +558,25 @@
    ---------- Socket options ----------
    ------------------------------------
 */
+
+/**
+ * LWIP_POSIX_SOCKETS_IO_NAMES==1: Enable POSIX-style sockets functions names.
+ * Disable this option if you use a POSIX operating system that uses the same
+ * names (read, write & close). (only used if you use sockets.c)
+ */
+#define LWIP_POSIX_SOCKETS_IO_NAMES     0
+
+/**
+ * LWIP_SOCKET_OFFSET==n: Increases the file descriptor number created by LwIP with n.
+ * This can be useful when there are multiple APIs which create file descriptors.
+ * When they all start with a different offset and you won't make them overlap you can
+ * re implement read/write/close/ioctl/fnctl to send the requested action to the right
+ * library (sharing select will need more work though).
+ */
+#ifndef LWIP_SOCKET_OFFSET
+#define LWIP_SOCKET_OFFSET              3
+#endif
+
 /**
  * LWIP_SO_SNDTIMEO==1: Enable send timeout for sockets/netconns and
  * SO_SNDTIMEO processing.


### PR DESCRIPTION
This patch gets the newlib standard stream descriptors playing well with the lwip socket descriptors and the spiffs file descriptors. The LWIP_SOCKET_OFFSET is now defined to be 3, rather than zero, to avoid clashing with the standard stream descriptors, and the SPIFFS_FILEHDL_OFFSET is bumped up to start after the lwip descriptors.

**This is not yet ready to merge.** I need to seek help from upstream lwip on the error that was disabled to allow this to build, why LWIP_SOCKET_OFFSET can not be used with an external FD_SET. A quick inspection did not find many problems, so I am probably missing something. But perhaps this will allow progress and more testing and feedback.

See also https://github.com/SuperHouse/esp-open-rtos/issues/445