### PR TITLE
wificfg bugfix and enhancements

### DIFF
--- a/examples/wificfg/wificfg.c
+++ b/examples/wificfg/wificfg.c
@@ -89,6 +89,7 @@ void user_init(void)
     printf("SDK version:%s\n", sdk_system_get_sdk_version());
 
     sdk_wifi_set_sleep_type(WIFI_SLEEP_MODEM);
-
-    wificfg_init(80, dispatch_list);
+    if (!wificfg_init(80, dispatch_list)) {
+        printf("Failed to start AP\n");
+    }
 }

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -1776,33 +1776,33 @@ static void dns_task(void *pvParameters)
 }
 
 /**
- * @brief      Sanetize SSID. If configuring an AP containing the characters in
+ * @brief      Sanitize SSID. If configuring an AP containing the characters in
  *             'illegals', the ESP will start an insecure AP named ESP_<macaddr>
  *             Any illegal characters will be replaced by _
  *
  * @param      ssid   the SSID
  *
- * @return     true if name got sanetized.
+ * @return     true if name got sanitized.
  */
-static bool sanetize_ssid(char *ssid)
+static bool sanitize_ssid(char *ssid)
 {
-    bool sanetized = false;
+    bool sanitized = false;
     char *illegals = "+-<> "; // There might me more characters that are illegal
     uint8_t num_illegals = strlen(illegals);
     if (!ssid) {
-        return sanetized;
+        return sanitized;
     }
     while(*ssid) {
         for (uint32_t i = 0; i < num_illegals; i++) {
             if (*ssid == illegals[i]) {
                 *ssid = '_';
-                sanetized = true;
+                sanitized = true;
                 break;
             }
         }
         ssid++;
     }
-    return sanetized;
+    return sanitized;
 }
 
 bool wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
@@ -1821,12 +1821,12 @@ bool wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
     }
 
     sysparam_get_string("wifi_ap_ssid", &wifi_ap_ssid);
-    if (sanetize_ssid(wifi_ap_ssid)) {
+    if (sanitize_ssid(wifi_ap_ssid)) {
         sysparam_set_string("wifi_ap_ssid", wifi_ap_ssid);
     }
     sysparam_get_string("wifi_ap_password", &wifi_ap_password);
     sysparam_get_string("wifi_sta_ssid", &wifi_sta_ssid);
-    if (sanetize_ssid(wifi_sta_ssid)) {
+    if (sanitize_ssid(wifi_sta_ssid)) {
         sysparam_set_string("wifi_sta_ssid", wifi_sta_ssid);
     }
     sysparam_get_string("wifi_sta_password", &wifi_sta_password);

--- a/extras/wificfg/wificfg.h
+++ b/extras/wificfg/wificfg.h
@@ -88,9 +88,10 @@ typedef struct {
 /*
  * Start the Wifi Configuration http server task. The IP port number
  * and a path dispatch list are needed. The dispatch list can not be
- * stack allocated as it is passed to another task.
+ * stack allocated as it is passed to another task. Returns true if the
+ * selected AP was successfully started.
  */
-void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch);
+bool wificfg_init(uint32_t port, const wificfg_dispatch *dispatch);
 
 /*
  * Support for reading a form name or value from the socket. The name or value


### PR DESCRIPTION
I have started using the excellent wificfg code and found some "undocumented features". The Espressif code gets upset if the SSID contains certain characters or is less than 8 characters in length. This would result in an unsecured AP called "ESP_<last_three_bytes_of_macaddr>"

Additionally, it is not possible to change the SSID following a first init unless the entire flash is erased. I added a note on that.

I took the liberty to redefine ```wificfg_init``` to return a bool indicating if the AP start was successful. My application would like to know this.

```sanitize_ssid``` clears up the SSID so as not to upset the Espressif code.

A bug was fixed in the ```wifi_sta_enable``` / ```wifi_ap_enable``` logic.

While on the topic I would like to discuss ```extras/wificfg```. I would very much like to move everything under ```content/``` and the entire ```wificfg_dispatch_list``` to the application in```examples/wificfg```. The reason is to be able to use a "clean" wificfg extras and add content per application.