### PR TITLE
Fix a printf issue.

### DIFF
--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -138,7 +138,7 @@ __attribute__((weak)) long _read_r( struct _reent *r, int fd, char *ptr, int len
         return lwip_read(fd, ptr, len);
     }
     if (fd == r->_stdin->_file) {
-        _read_stdin_r(r, fd, ptr, len);
+        return _read_stdin_r(r, fd, ptr, len);
     }
     r->_errno = EBADF;
     return -1;

--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -103,7 +103,7 @@ __attribute__((weak)) long _write_r(struct _reent *r, int fd, const char *ptr, i
         return lwip_write(fd, ptr, len);
     }
     if (fd == r->_stdout->_file) {
-        current_stdout_write_r(r, fd, ptr, len);
+        return current_stdout_write_r(r, fd, ptr, len);
     }
     r->_errno = EBADF;
     return -1;


### PR DESCRIPTION
When I pass a multi-line string to printf, only the first line is printed after PR #437 .
This fixes it.
