### PR TITLE
Fix a typo in ssd1306 driver that prevents compiling with c++ compiler

### DIFF
--- a/extras/ssd1306/ssd1306.h
+++ b/extras/ssd1306/ssd1306.h
@@ -526,7 +526,6 @@ int ssd1306_start_scroll_hori(const ssd1306_t *dev, bool way, uint8_t start, uin
 int ssd1306_start_scroll_hori_vert(const ssd1306_t *dev, bool way, uint8_t start, uint8_t stop, uint8_t dy, ssd1306_scroll_t frame);
 
 #ifdef __cplusplus
-extern "C"
 }
 #endif
 


### PR DESCRIPTION
Simple fix.  Discovered while working on a project and thought others would find it useful.