### PR TITLE
pwm fix 

### DIFF
--- a/core/esp_timer.c
+++ b/core/esp_timer.c
@@ -83,6 +83,11 @@ int timer_set_frequency(const timer_frc_t frc, uint32_t freq)
     uint32_t counts = 0;
     timer_clkdiv_t div = timer_freq_to_div(freq);
 
+    if(freq == 0) //can't divide by 0
+    {
+        return -EINVAL;
+    }
+
     counts = timer_freq_to_count(frc, freq, div);
     if(counts == 0)
     {

--- a/examples/pwm_test/pwm_test.c
+++ b/examples/pwm_test/pwm_test.c
@@ -35,7 +35,7 @@ void user_init(void)
 
     printf("pwm_init(1, [14])\n");
     pins[0] = 14;
-    pwm_init(1, pins);
+    pwm_init(1, pins, false);
 
     printf("pwm_set_freq(1000)     # 1 kHz\n");
     pwm_set_freq(1000);

--- a/extras/pwm/pwm.c
+++ b/extras/pwm/pwm.c
@@ -74,7 +74,7 @@ static void IRAM frc1_interrupt_handler(void *arg)
     pwmInfo._step = step;
 }
 
-void pwm_init(uint8_t npins, const uint8_t* pins)
+void pwm_init(uint8_t npins, const uint8_t* pins, uint8_t reverse)
 {
     /* Assert number of pins is correct */
     if (npins > MAX_PWM_PINS)

--- a/extras/pwm/pwm.c
+++ b/extras/pwm/pwm.c
@@ -140,7 +140,7 @@ void pwm_set_duty(uint16_t duty)
     pwmInfo.dutyCycle = duty;
     if (duty == 0 || duty == UINT16_MAX)
     {
-      pwmInfo.output = (duty == UINT16_MAX);
+        pwmInfo.output = (duty == UINT16_MAX);
     }
     debug("Duty set at %u",pwmInfo.dutyCycle);
     pwm_restart();
@@ -176,10 +176,10 @@ void pwm_start()
     }
     else
     {
-      for (uint8_t i = 0; i < pwmInfo.usedPins; ++i)
-      {
-        gpio_write(pwmInfo.pins[i].pin, pwmInfo.reverse ? !pwmInfo.output : pwmInfo.output );
-      }       
+        for (uint8_t i = 0; i < pwmInfo.usedPins; ++i)
+        {
+            gpio_write(pwmInfo.pins[i].pin, pwmInfo.reverse ? !pwmInfo.output : pwmInfo.output );
+        }       
     }
     debug("PWM started");
     pwmInfo.running = 1;
@@ -189,13 +189,10 @@ void pwm_stop()
 {
     timer_set_interrupts(FRC1, false);
     timer_set_run(FRC1, false);
-    if (pwmInfo.dutyCycle == 0 || pwmInfo.dutyCycle == UINT16_MAX)
+    for (uint8_t i = 0; i < pwmInfo.usedPins; ++i)
     {
-      for (uint8_t i = 0; i < pwmInfo.usedPins; ++i)
-      {
         gpio_write(pwmInfo.pins[i].pin, pwmInfo.reverse ? true : false);
-      }       
-    }
+    }       
     debug("PWM stopped");
     pwmInfo.running = 0;
 }

--- a/extras/pwm/pwm.c
+++ b/extras/pwm/pwm.c
@@ -127,6 +127,7 @@ void pwm_set_freq(uint16_t freq)
         pwmInfo._maxLoad = timer_get_load(FRC1);
         pwmInfo.freq = freq;
         debug("Frequency set at %u",pwmInfo.freq);
+        debug("MaxLoad is %u",pwmInfo._maxLoad);
     }
 
     if (pwmInfo.running)
@@ -161,6 +162,13 @@ void pwm_start()
     pwmInfo._offLoad = pwmInfo._maxLoad - pwmInfo._onLoad;
     pwmInfo._step = PERIOD_ON;
 
+    if(!pwmInfo._onLoad)
+    {
+        debug("Can't set timer with low duty and frequency settings, put duty at 0");
+        pwmInfo.dutyCycle = 0;
+    }
+
+    // 0% and 100% duty cycle are special cases: constant output.
     if (pwmInfo.dutyCycle > 0 && pwmInfo.dutyCycle < UINT16_MAX)
     {
         // Trigger ON

--- a/extras/pwm/pwm.c
+++ b/extras/pwm/pwm.c
@@ -12,6 +12,12 @@
 #include <FreeRTOS.h>
 #include <esp8266.h>
 
+#ifdef PWM_DEBUG
+#define debug(fmt, ...) printf("%s: " fmt "\n", "PWM", ## __VA_ARGS__)
+#else
+#define debug(fmt, ...)
+#endif
+
 typedef struct PWMPinDefinition
 {
     uint8_t pin;
@@ -43,7 +49,7 @@ typedef struct pwmInfoDefinition
 
 static PWMInfo pwmInfo;
 
-static void frc1_interrupt_handler(void *arg)
+static void IRAM frc1_interrupt_handler(void *arg)
 {
     uint8_t i = 0;
     bool out = true;
@@ -71,7 +77,7 @@ void pwm_init(uint8_t npins, const uint8_t* pins)
     /* Assert number of pins is correct */
     if (npins > MAX_PWM_PINS)
     {
-        printf("Incorrect number of PWM pins (%d)\n", npins);
+        debug("Incorrect number of PWM pins (%d)\n", npins);
         return;
     }
 
@@ -117,9 +123,12 @@ void pwm_set_freq(uint16_t freq)
     timer_set_frequency(FRC1, freq);
     pwmInfo._maxLoad = timer_get_load(FRC1);
 
-    if (pwmInfo.running)
+    if (pwmInfo.dutyCycle > 0 && pwmInfo.dutyCycle < UINT16_MAX)
     {
-        pwm_start();
+        if (pwmInfo.running)
+        {
+            pwm_start();
+        }
     }
 }
 

--- a/extras/pwm/pwm.c
+++ b/extras/pwm/pwm.c
@@ -123,12 +123,9 @@ void pwm_set_freq(uint16_t freq)
     timer_set_frequency(FRC1, freq);
     pwmInfo._maxLoad = timer_get_load(FRC1);
 
-    if (pwmInfo.dutyCycle > 0 && pwmInfo.dutyCycle < UINT16_MAX)
+    if (pwmInfo.running)
     {
-        if (pwmInfo.running)
-        {
-            pwm_start();
-        }
+        pwm_start();
     }
 }
 
@@ -174,10 +171,13 @@ void pwm_start()
         gpio_write(pwmInfo.pins[i].pin, true);
     }
 
-    timer_set_load(FRC1, pwmInfo._onLoad);
-    timer_set_reload(FRC1, false);
-    timer_set_interrupts(FRC1, true);
-    timer_set_run(FRC1, true);
+    if (pwmInfo.dutyCycle > 0 && pwmInfo.dutyCycle < UINT16_MAX)
+    {
+        timer_set_load(FRC1, pwmInfo._onLoad);
+        timer_set_reload(FRC1, false);
+        timer_set_interrupts(FRC1, true);
+        timer_set_run(FRC1, true);
+    }
 
     pwmInfo.running = 1;
 }

--- a/extras/pwm/pwm.h
+++ b/extras/pwm/pwm.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-void pwm_init(uint8_t npins, const uint8_t* pins);
+void pwm_init(uint8_t npins, const uint8_t* pins, uint8_t reverse);
 void pwm_set_freq(uint16_t freq);
 void pwm_set_duty(uint16_t duty);
 

--- a/extras/pwm/pwm.h
+++ b/extras/pwm/pwm.h
@@ -16,14 +16,41 @@
 extern "C" {
 #endif
 
-//Warning: Printf disturb pwm, use uart_putc instead.
+//Warning: Printf disturb pwm. You can use "uart_putc" instead.
 
+/**
+ * Initialize pwm
+ * @param npins Number of pwm pin used
+ * @param pins Array pointer to the pins
+ * @param reverse If true, the pwm work in reverse mode
+ */    
 void pwm_init(uint8_t npins, const uint8_t* pins, uint8_t reverse);
+
+/**
+ * Set PWM frequency. If error, frequency not set
+ * @param freq PWM frequency value in Hertz
+ */  
 void pwm_set_freq(uint16_t freq);
+
+/**
+ * Set Duty between 0 and UINT16_MAX
+ * @param duty Duty value
+ */  
 void pwm_set_duty(uint16_t duty);
 
+/**
+ * Restart the pwm signal
+ */  
 void pwm_restart();
+
+/**
+ * Start the pwm signal
+ */  
 void pwm_start();
+
+/**
+ * Stop the pwm signal
+ */  
 void pwm_stop();
 
 #ifdef __cplusplus

--- a/extras/pwm/pwm.h
+++ b/extras/pwm/pwm.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+//Warning: Printf disturb pwm, use uart_putc instead.
+
 void pwm_init(uint8_t npins, const uint8_t* pins, uint8_t reverse);
 void pwm_set_freq(uint16_t freq);
 void pwm_set_duty(uint16_t duty);


### PR DESCRIPTION
-Special duty state 0 and UINT16_MAX   crash when you change frequency  fix
-IRAM handler improvements
-Replace printf by debug system

I tested with a motor.
Can someone confirm to me this:  
If i put handler on  IRAM, it is improvement performance.  pwm interupt is called often.
No need to load function on flash with SPI transaction?
