### PR TITLE
Fixed Repeated-start in I2C

### DIFF
--- a/extras/i2c/i2c.c
+++ b/extras/i2c/i2c.c
@@ -344,8 +344,6 @@ int i2c_slave_read(uint8_t bus, uint8_t slave_addr, const uint8_t *data, uint8_t
             goto error;
         if (!i2c_write(bus, *data))
             goto error;
-        if (!i2c_stop(bus))
-            goto error;
     }
     i2c_start(bus);
     if (!i2c_write(bus, slave_addr << 1 | 1)) // Slave address + read


### PR DESCRIPTION
The i2c_stop should not be there.
We have to keep the bus started and then issue again the i2c_start in order for the function to handle correctly the repeated-start.