### PR TITLE
Fix the SPIFFS POSIX API (#489)

### DIFF
--- a/extras/spiffs/esp_spiffs.c
+++ b/extras/spiffs/esp_spiffs.c
@@ -90,7 +90,7 @@ void esp_spiffs_init(uint32_t addr, uint32_t size)
     config.hal_write_f = esp_spiffs_write;
     config.hal_erase_f = esp_spiffs_erase;
 
-    config.fh_ix_offset = 3;
+    config.fh_ix_offset = SPIFFS_FILEHDL_OFFSET;
 
 }
 


### PR DESCRIPTION
The commit ebdd2f9 defined some offsets to differentiate between the
standard, socket and file descriptors.

SPIFFS_FILEHDL_OFFSET was updated accordingly but the code didn't use
that constant and this broke the SPIFFS POSIX API.

Fix it by initializing the fh_ix_offset field of the spiffs_config
structure to SPIFFS_FILEHDL_OFFSET.