### PR TITLE
color and timing (ws2812_i2s)

### DIFF
--- a/examples/ws2812_i2s/ws2812_i2s_colour_loop.c
+++ b/examples/ws2812_i2s/ws2812_i2s_colour_loop.c
@@ -41,7 +41,7 @@ static int fix_index(int index)
 
 static ws2812_pixel_t next_colour()
 {
-    ws2812_pixel_t colour = {0, 0, 0, 0};
+    ws2812_pixel_t colour = { {0, 0, 0, 0} };
     colour.red = rand() % 256;
     colour.green = rand() % 256;
     colour.blue = rand() % 256;

--- a/extras/ws2812_i2s/ws2812_i2s.h
+++ b/extras/ws2812_i2s/ws2812_i2s.h
@@ -31,11 +31,14 @@
 extern "C" {
 #endif
 
-typedef struct {
-    uint8_t red;
-    uint8_t green;
-    uint8_t blue;
-    uint8_t white;
+typedef union {
+    struct {
+        uint8_t blue; //LSB
+        uint8_t green;
+        uint8_t red;
+        uint8_t white;
+    };
+    uint32_t color; // 0xWWRRGGBB
 } ws2812_pixel_t;
 
 typedef enum {


### PR DESCRIPTION
- Add a way to set color with one variable, "RGB888" standard.

I discovered a bug or a problem with current i2s library.
When you do 2 update without delay, second update don't work.
```
ws2812_i2s_update(pixels, PIXEL_RGB);
ws2812_i2s_update(pixels, PIXEL_RGB);
```
Was thinking that this line : `while (i2s_dma_processing) {}; ` will prevent this but not.
It is work when i add this:
`sdk_os_delay_us(260 + 30 * (dma_buffer_size / type)); `

I can fix with a system that control the minimum time in us and return error is we cant update. (sdk api) but i wondering if i2s lib dont set flag correctly ? any clue ?
