### PR TITLE
Allow overrides of sntp.h

### DIFF
--- a/extras/sntp/sntp.c
+++ b/extras/sntp/sntp.c
@@ -36,7 +36,7 @@
 
 #include "lwip/opt.h"
 
-#include "sntp.h"
+#include <sntp.h>
 
 #include "lwip/timeouts.h"
 #include "lwip/udp.h"

--- a/extras/sntp/sntp_fun.c
+++ b/extras/sntp/sntp_fun.c
@@ -11,7 +11,7 @@
 #include <espressif/esp_common.h>
 #include <esp/timer.h>
 #include <esp/rtc_regs.h>
-#include "sntp.h"
+#include <sntp.h>
 
 #define TIMER_COUNT			RTC.COUNTER
 


### PR DESCRIPTION
Changed quote marks with triangle brackets
for sntp.h to allow user creating a custom sntp.h