### PR TITLE
Makefile: add flag to disable C++ components

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -97,10 +97,14 @@ $(1)_DEFAULT_ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 $(1)_ROOT ?= $$($(1)_DEFAULT_ROOT)
 $(1)_OBJ_DIR   = $(call lc,$(BUILD_DIR)$(1)/)
 ### determine source files and object files ###
-$(1)_SRC_FILES ?= $$(foreach sdir,$$($(1)_SRC_DIR), 				\
-			$$(wildcard $$(sdir)/*.c) $$(wildcard $$(sdir)/*.S) 	\
-			$$(wildcard $$(sdir)/*.cpp)) 				\
+$(1)_TMP_SRC_FILES = $$(foreach sdir,$$($(1)_SRC_DIR), 			\
+			$$(wildcard $$(sdir)/*.c) $$(wildcard $$(sdir)/*.S)) 	\
 			$$($(1)_EXTRA_SRC_FILES)
+ifeq ($(ENABLE_CXX),1)
+		$(1)_TMP_SRC_FILES += $$(foreach sdir,$$($(1)_SRC_DIR), \
+			$$(wildcard $$(sdir)/*.cpp))
+endif
+$(1)_SRC_FILES ?= $$($(1)_TMP_SRC_FILES)
 $(1)_REAL_SRC_FILES = $$(foreach sfile,$$($(1)_SRC_FILES),$$(realpath $$(sfile)))
 $(1)_REAL_ROOT = $$(realpath $$($(1)_ROOT))
 # patsubst here substitutes real component root path for the relative OBJ_DIR path, making things short again

--- a/parameters.mk
+++ b/parameters.mk
@@ -85,6 +85,8 @@ SPLIT_SECTIONS ?= 1
 # compile without warnings to be accepted.
 WARNINGS_AS_ERRORS ?= 0
 
+ENABLE_CXX ?= 1
+
 # Common flags for both C & C++_
 C_CXX_FLAGS ?= -Wall -Wl,-EL -nostdlib $(EXTRA_C_CXX_FLAGS)
 # Flags for C only


### PR DESCRIPTION
When experimenting with toolchains, I found it difficult to build a C++-enabled toolchain with crosstool-NG. Therefore I propose to add a flag which disables building `*.cpp` files. The only C++ file in `core` is `cplusplus_operators.cpp` which is not an essential part if one isn't programming in C++. Disabling C++ files in Makefile enables building `esp-open-rtos` with a C-only toolchain.