### PR TITLE
wificfg: remove the AP WEP mode option

### DIFF
--- a/extras/wificfg/content/wificfg/ap.html
+++ b/extras/wificfg/content/wificfg/ap.html
@@ -49,8 +49,6 @@
 "<dd><select id=\"am\" name=\"ap_authmode\">"
 "<option value=\"0\"",
 ">Open</option>"
-"<option value=\"1\"",
-">WEP</option>"
 "<option value=\"2\"",
 ">WPA_PSK</option>"
 "<option value=\"3\"",

--- a/extras/wificfg/content/wificfg/ap.html
+++ b/extras/wificfg/content/wificfg/ap.html
@@ -80,6 +80,9 @@
 "<dt><label for=\"dns_en\">DNS enabled</label></dt>"
 "<dd><input id=\"dns_en\" type=\"checkbox\" name=\"ap_dns\" value=\"1\" ",
 " /></dd>"
+"<dt><label for=\"dns_en\">mDNS enabled</label></dt>"
+"<dd><input id=\"dns_en\" type=\"checkbox\" name=\"ap_mdns\" value=\"1\" ",
+" /></dd>"
 "</dl>"
 "<center><input type=\"reset\">&nbsp;<input type=\"submit\" value=\"Save\"></center>"
 "</fieldset>"

--- a/extras/wificfg/content/wificfg/sta.html
+++ b/extras/wificfg/content/wificfg/sta.html
@@ -60,7 +60,7 @@
 "pattern=\"(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)_*(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)_*){3}\" "
 "name=\"sta_gateway\" placeholder=\"192.168.1.1\" value=\"",
 "\"></dd>"
-"<dt><label for=\"mdns\">Enable mDNS</label></dt>"
+"<dt><label for=\"mdns\">mDNS enabled</label></dt>"
 "<dd><input id=\"mdns\" type=\"checkbox\" name=\"sta_mdns\" value=\"1\" ",
 " /></dd>"
 "</dl>"

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -1142,33 +1142,31 @@ static int handle_wifi_ap(int s, wificfg_method method,
 
         if (wificfg_write_string_chunk(s, http_wifi_ap_content[8], buf, len) < 0) return -1;
 
-        int8_t wifi_ap_authmode = 4;
+        int8_t wifi_ap_authmode = AUTH_WPA_WPA2_PSK;
         sysparam_get_int8("wifi_ap_authmode", &wifi_ap_authmode);
-        if (wifi_ap_authmode == 0 && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
+        if (wifi_ap_authmode == AUTH_OPEN && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
         if (wificfg_write_string_chunk(s, http_wifi_ap_content[9], buf, len) < 0) return -1;
-        if (wifi_ap_authmode == 1 && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
+        if (wifi_ap_authmode == AUTH_WPA_PSK && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
         if (wificfg_write_string_chunk(s, http_wifi_ap_content[10], buf, len) < 0) return -1;
-        if (wifi_ap_authmode == 2 && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
+        if (wifi_ap_authmode == AUTH_WPA2_PSK && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
         if (wificfg_write_string_chunk(s, http_wifi_ap_content[11], buf, len) < 0) return -1;
-        if (wifi_ap_authmode == 3 && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[12], buf, len) < 0) return -1;
-        if (wifi_ap_authmode == 4 && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
+        if (wifi_ap_authmode == AUTH_WPA_WPA2_PSK && wificfg_write_string_chunk(s, " selected", buf, len) < 0) return -1;
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[13], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[12], buf, len) < 0) return -1;
 
         int8_t wifi_ap_max_conn = 3;
         sysparam_get_int8("wifi_ap_max_conn", &wifi_ap_max_conn);
         snprintf(buf, len, "%u", wifi_ap_max_conn);
         if (wificfg_write_string_chunk(s, buf, buf, len) < 0) return -1;
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[14], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[13], buf, len) < 0) return -1;
 
         int32_t wifi_ap_beacon_interval = 100;
         sysparam_get_int32("wifi_ap_beacon_interval", &wifi_ap_beacon_interval);
         snprintf(buf, len, "%u", wifi_ap_beacon_interval);
         if (wificfg_write_string_chunk(s, buf, buf, len) < 0) return -1;
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[15], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[14], buf, len) < 0) return -1;
 
         char *wifi_ap_ip_addr = NULL;
         sysparam_get_string("wifi_ap_ip_addr", &wifi_ap_ip_addr);
@@ -1178,7 +1176,7 @@ static int handle_wifi_ap(int s, wificfg_method method,
             if (wificfg_write_string_chunk(s, buf, buf, len) < 0) return -1;
         }
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[16], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[15], buf, len) < 0) return -1;
 
         char *wifi_ap_netmask = NULL;
         sysparam_get_string("wifi_ap_netmask", &wifi_ap_netmask);
@@ -1188,19 +1186,19 @@ static int handle_wifi_ap(int s, wificfg_method method,
             if (wificfg_write_string_chunk(s, buf, buf, len) < 0) return -1;
         }
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[17], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[16], buf, len) < 0) return -1;
 
         int8_t wifi_ap_dhcp_leases = 4;
         sysparam_get_int8("wifi_ap_dhcp_leases", &wifi_ap_dhcp_leases);
         snprintf(buf, len, "%u", wifi_ap_dhcp_leases);
         if (wificfg_write_string_chunk(s, buf, buf, len) < 0) return -1;
 
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[18], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[17], buf, len) < 0) return -1;
 
         int8_t wifi_ap_dns = 1;
         sysparam_get_int8("wifi_ap_dns", &wifi_ap_dns);
         if (wifi_ap_dns && wificfg_write_string_chunk(s, "checked", buf, len) < 0) return -1;
-        if (wificfg_write_string_chunk(s, http_wifi_ap_content[19], buf, len) < 0) return -1;
+        if (wificfg_write_string_chunk(s, http_wifi_ap_content[18], buf, len) < 0) return -1;
 
         if (wificfg_write_chunk_end(s) < 0) return -1;
     }
@@ -1281,8 +1279,10 @@ static int handle_wifi_ap_post(int s, wificfg_method method,
             }
             case FORM_NAME_AP_AUTHMODE: {
                 uint32_t mode = strtoul(buf, NULL, 10);
-                if (mode <= 5)
+                if (mode == AUTH_OPEN || mode == AUTH_WPA_PSK ||
+                    mode == AUTH_WPA2_PSK || mode == AUTH_WPA_WPA2_PSK) {
                     sysparam_set_int8("wifi_ap_authmode", mode);
+                }
                 break;
             }
             case FORM_NAME_AP_MAX_CONN: {
@@ -2097,8 +2097,9 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
         /* Read and validate paramenters. */
         int8_t wifi_ap_ssid_hidden = 0;
         sysparam_get_int8("wifi_ap_ssid_hidden", &wifi_ap_ssid_hidden);
-        if (wifi_ap_ssid_hidden < 0 || wifi_ap_ssid_hidden > 1)
+        if (wifi_ap_ssid_hidden < 0 || wifi_ap_ssid_hidden > 1) {
             wifi_ap_ssid_hidden = 1;
+        }
 
         int8_t wifi_ap_channel = 6;
         sysparam_get_int8("wifi_ap_channel", &wifi_ap_channel);
@@ -2119,18 +2120,22 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
 
         int8_t wifi_ap_authmode = AUTH_WPA_WPA2_PSK;
         sysparam_get_int8("wifi_ap_authmode", &wifi_ap_authmode);
-        if (wifi_ap_authmode < AUTH_OPEN || wifi_ap_authmode > AUTH_MAX)
+        if (wifi_ap_authmode != AUTH_OPEN && wifi_ap_authmode != AUTH_WPA_PSK &&
+            wifi_ap_authmode != AUTH_WPA2_PSK && wifi_ap_authmode != AUTH_WPA_WPA2_PSK) {
             wifi_ap_authmode = AUTH_WPA_WPA2_PSK;
+        }
 
         int8_t wifi_ap_max_conn = 3;
         sysparam_get_int8("wifi_ap_max_conn", &wifi_ap_max_conn);
-        if (wifi_ap_max_conn < 1 || wifi_ap_max_conn > 8)
+        if (wifi_ap_max_conn < 1 || wifi_ap_max_conn > 8) {
             wifi_ap_max_conn = 3;
+        }
 
         int32_t wifi_ap_beacon_interval = 100;
         sysparam_get_int32("wifi_ap_beacon_interval", &wifi_ap_beacon_interval);
-        if (wifi_ap_beacon_interval < 0 || wifi_ap_beacon_interval > 1000)
+        if (wifi_ap_beacon_interval < 0 || wifi_ap_beacon_interval > 1000) {
             wifi_ap_beacon_interval = 100;
+        }
 
         /* Default AP IP address and netmask. */
         char *wifi_ap_ip_addr = NULL;

--- a/extras/wificfg/wificfg.h
+++ b/extras/wificfg/wificfg.h
@@ -97,7 +97,7 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch);
  * is truncated to the buffer length. The number of characters read is limited
  * to the remainder which is updated. The 'valp' flag is set if a value follows.
  */
-int wificfg_form_name_value(int s, bool *valp, size_t *rem, char *buf, size_t len);
+ssize_t wificfg_form_name_value(int s, bool *valp, size_t *rem, char *buf, size_t len);
 
 /* Support for form url-encoding decoder. */
 void wificfg_form_url_decode(char *string);
@@ -106,20 +106,17 @@ void wificfg_form_url_decode(char *string);
 void wificfg_html_escape(char *string, char *buf, size_t len);
 
 /* Support for writing a string in a response. */
-int wificfg_write_string(int s, const char *str);
+ssize_t wificfg_write_string(int s, const char *str);
 
 /* Support for writing a string in a response, with chunk transfer encoding.
  * An optional buffer may be supplied to use to construct a chunk with the
  * header and trailer, reducing the number of write() calls, and the str may be
  * at the start of this buffer.
  */
-int wificfg_write_string_chunk(int s, const char *str, char *buf, size_t len);
+ssize_t wificfg_write_string_chunk(int s, const char *str, char *buf, size_t len);
 
 /* Write a chunk transfer encoding end marker. */
-int wificfg_write_chunk_end(int s);
-
-/* Write a chunk offset 4 bytes into the buffer. */
-int wificfg_write_buffer_chunk(int s, char *buf);
+ssize_t wificfg_write_chunk_end(int s);
 
 /* Write a html title meta data, using the hostname or AP SSI. */
 int wificfg_write_html_title(int s, char *buf, size_t len, const char *str);

--- a/lwip/include/lwipopts.h
+++ b/lwip/include/lwipopts.h
@@ -297,6 +297,12 @@
 #define DNS_MAX_NAME_LENGTH 128
 #endif
 
+/** Set this to 1 to enable querying ".local" names via mDNS
+ *  using a One-Shot Multicast DNS Query */
+#ifndef LWIP_DNS_SUPPORT_MDNS_QUERIES
+#define LWIP_DNS_SUPPORT_MDNS_QUERIES  1
+#endif
+
 /*
    ---------------------------------
    ---------- UDP options ----------


### PR DESCRIPTION
The WEP mode does not appear to be implement in the sdk for the AP mode, and defaults to open when WEP is requested which is probably not intended. Remove the WEP option from the wifi config interface.