### PR TITLE
softap: allow output of multicast frames.

### DIFF
--- a/open_esplibs/libnet80211/wl_cnx.c
+++ b/open_esplibs/libnet80211/wl_cnx.c
@@ -192,6 +192,11 @@ struct sdk_cnx_node *sdk_cnx_node_search(uint8_t mac[6])
 
     struct sdk_cnx_node **cnx_nodes = sdk_g_ic.v.softap_netif_info->cnx_nodes;
 
+    /* Multicast addresses */
+    if (mac[0] & 0x01) {
+        return cnx_nodes[0];
+    }
+
     int i = 0;
     do {
         struct sdk_cnx_node *cnx_node = cnx_nodes[i];


### PR DESCRIPTION
Multicast frames were being dropped by `ieee80211_output_pbuf`. It appears to look up the destination address using `cnx_node_search` which only has an entry for the broadcast address (all ones). This patch modifies `cnx_node_search` to return the broadcast `cnx_node` for the multicast addresses too.

This is needed to support services such as mDNS on the softap interface.

This patch might be a bit of a stretch, perhaps better to patch `ieee80211_output_pbuf`, but there is no source code.