### PR TITLE
FreeRTOS v10 fixes.

### DIFF
--- a/FreeRTOS/Source/include/stream_buffer.h
+++ b/FreeRTOS/Source/include/stream_buffer.h
@@ -52,6 +52,10 @@
 #ifndef STREAM_BUFFER_H
 #define STREAM_BUFFER_H
 
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
 /**
  * Type by which stream buffers are referenced.  For example, a call to
  * xStreamBufferCreate() returns an StreamBufferHandle_t variable that can
@@ -843,7 +847,7 @@ StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
 #endif
 
 #if defined( __cplusplus )
-extern "C" {
+}
 #endif
 
 #endif	/* !defined( STREAM_BUFFER_H ) */

--- a/FreeRTOS/Source/include/task.h
+++ b/FreeRTOS/Source/include/task.h
@@ -44,8 +44,8 @@ extern "C" {
  * MACROS AND DEFINITIONS
  *----------------------------------------------------------*/
 
-#define tskKERNEL_VERSION_NUMBER "V9.0.0"
-#define tskKERNEL_VERSION_MAJOR 9
+#define tskKERNEL_VERSION_NUMBER "V10.0.0"
+#define tskKERNEL_VERSION_MAJOR 10
 #define tskKERNEL_VERSION_MINOR 0
 #define tskKERNEL_VERSION_BUILD 0
 

--- a/FreeRTOS/Source/tasks.c
+++ b/FreeRTOS/Source/tasks.c
@@ -110,6 +110,7 @@ set then don't fill the stack so there is no unnecessary dependency on memset. *
 /*
  * Macros used by vListTask to indicate which state a task is in.
  */
+#define tskRUNNING_CHAR		( 'X' )
 #define tskBLOCKED_CHAR		( 'B' )
 #define tskREADY_CHAR		( 'R' )
 #define tskDELETED_CHAR		( 'D' )
@@ -4209,6 +4210,9 @@ TCB_t *pxTCB;
 			{
 				switch( pxTaskStatusArray[ x ].eCurrentState )
 				{
+					case eRunning:		cStatus = tskRUNNING_CHAR;
+										break;
+
 					case eReady:		cStatus = tskREADY_CHAR;
 										break;
 


### PR DESCRIPTION
svn r2522:
FreeRTOS kernel: Fix extern "C" { in stream_buffer.h.
FreeRTOS kernel: Correct tskKERNEL_VERSION_NUMBER and tskKERNEL_VERSION_MAJOR constants for V10.
Ensure the currently executing task is printed correctly in vTaskList().