### PR TITLE
Reuse the startup stack for the dynamic heap.

### DIFF
--- a/core/app_main.c
+++ b/core/app_main.c
@@ -339,9 +339,15 @@ void sdk_wdt_init(void) {
     sdk_pp_soft_wdt_init();
 }
 
+extern void *xPortSupervisorStackPointer;
+
 // .irom0.text+0x474
 void sdk_user_init_task(void *params) {
     int phy_ver, pp_ver;
+
+    /* The start up stack is not used after scheduling has started, so all of
+     * the top area of RAM which was stack can be used for the dynamic heap. */
+    xPortSupervisorStackPointer = (void *)0x40000000;
 
     sdk_ets_timer_init();
     printf("\nESP-Open-SDK ver: %s compiled @ %s %s\n", OS_VERSION_STR, __DATE__, __TIME__);


### PR DESCRIPTION
Once scheduling has started, the startup stack is no longer usable, control can never return to that stack. So bump up the heap end in the first task that runs after scheduling has started. This gives back about 1k.

This is a proposal from investigations in https://github.com/SuperHouse/esp-open-rtos/issues/510

A concern is that it is not clear what the top of RAM is used for. It appears to be the start up stack, but might the ROM have stack allocated some memory there that it reuses, or have some other use? Writing to the area and reading back suggests it is not used.