### PR TITLE
sdk_system_print_meminfo: fix and correct heap end.

### DIFF
--- a/open_esplibs/libmain/user_interface.c
+++ b/open_esplibs/libmain/user_interface.c
@@ -63,10 +63,10 @@ static void _deep_sleep_phase2(void *timer_arg);
 static struct netif *_get_netif(uint32_t mode);
 
 // Linker-created values used by sdk_system_print_meminfo
-extern uint32_t _data_start, _data_end;
-extern uint32_t _rodata_start, _rodata_end;
-extern uint32_t _bss_start, _bss_end;
-extern uint32_t _heap_start;
+extern uint8_t _data_start[], _data_end[];
+extern uint8_t _rodata_start[], _rodata_end[];
+extern uint8_t _bss_start[], _bss_end[];
+extern uint8_t _heap_start[];
 
 #define _rom_reset_vector ((void (*)(void))0x40000080)
 
@@ -484,11 +484,14 @@ void sdk_system_station_got_ip_set(struct ip4_addr *ip, struct ip4_addr *mask, s
     }
 }
 
+extern void *xPortSupervisorStackPointer;
+
 void sdk_system_print_meminfo(void) {
-    printf("%s: 0x%x ~ 0x%x, len: %d\n", "data  ", _data_start, _data_end, _data_end - _data_start);
-    printf("%s: 0x%x ~ 0x%x, len: %d\n", "rodata", _rodata_start, _rodata_end, _rodata_end - _rodata_start);
-    printf("%s: 0x%x ~ 0x%x, len: %d\n", "bss   ", _bss_start, _bss_end, _bss_end - _bss_start);
-    printf("%s: 0x%x ~ 0x%x, len: %d\n", "heap  ", _heap_start, 0x3fffc000, 0x3fffc000 - _heap_start);
+    uint8_t *heap_end = xPortSupervisorStackPointer;
+    printf("%s: %p ~ %p, len: %d\n", "data  ", _data_start, _data_end, _data_end - _data_start);
+    printf("%s: %p ~ %p, len: %d\n", "rodata", _rodata_start, _rodata_end, _rodata_end - _rodata_start);
+    printf("%s: %p ~ %p, len: %d\n", "bss   ", _bss_start, _bss_end, _bss_end - _bss_start);
+    printf("%s: %p ~ %p, len: %d\n", "heap  ", _heap_start, heap_end, heap_end - _heap_start);
 }
 
 uint32_t sdk_system_get_free_heap_size(void) {


### PR DESCRIPTION
Address issues noted in https://github.com/SuperHouse/esp-open-rtos/issues/510