### PR TITLE
Reclaim a chunk of unused dram in the wdev bss area, 8000 bytes.

### DIFF
--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -61,6 +61,14 @@ IRAM void *_sbrk_r (struct _reent *r, ptrdiff_t incr)
     return (caddr_t) prev_heap_end;
 }
 
+
+/* Insert a disjoint region into the nano malloc pool. Create a malloc chunk,
+ * filling the size as newlib nano malloc expects, and then free it. */
+void nano_malloc_insert_chunk(void *start, size_t size) {
+    *(uint32_t *)start = size;
+    free(start + sizeof(size_t));
+}
+
 /* syscall implementation for stdio write to UART */
 __attribute__((weak)) ssize_t _write_stdout_r(struct _reent *r, int fd, const void *ptr, size_t len )
 {


### PR DESCRIPTION
Some people appear desperate for more dram, and there is 8000 bytes unused. This patch attempts to reclaim that region, to put it onto the malloc free list where is can be used. This is not ideal as it is a fragmented region, but it is dram so faster and more flexible than the 16k+ or iram that might also be added see https://github.com/SuperHouse/esp-open-rtos/issues/510 Some testing and feedback would be welcomed, perhaps also if someone could look over the wdev disassembly and see if they concur about the position and size of this region.