### PR TITLE
Flash size as megabytes

### DIFF
--- a/examples/i2s_audio/Makefile
+++ b/examples/i2s_audio/Makefile
@@ -1,6 +1,6 @@
 PROGRAM=i2s_audio_example
 EXTRA_COMPONENTS = extras/spiffs extras/i2s_dma
-FLASH_SIZE = 32
+FLASH_SIZE = 4
 
 # spiffs configuration
 SPIFFS_BASE_ADDR = 0x200000

--- a/examples/spiffs/Makefile
+++ b/examples/spiffs/Makefile
@@ -1,6 +1,6 @@
 PROGRAM=spiffs_example
 EXTRA_COMPONENTS = extras/spiffs
-FLASH_SIZE = 32
+FLASH_SIZE = 4
 
 # spiffs configuration
 SPIFFS_BASE_ADDR = 0x200000

--- a/examples/wificfg/local.mk
+++ b/examples/wificfg/local.mk
@@ -1,1 +1,1 @@
-FLASH_SIZE ?= 32
+FLASH_SIZE ?= 4

--- a/extras/spiffs/README.md
+++ b/extras/spiffs/README.md
@@ -29,7 +29,7 @@ and size is the location of SPIFFS region in SPI flash and its size.
 
 In order to use file system in a project the following steps should be made:
  * Add SPIFFS component in a project Makefile `EXTRA_COMPONENTS = extras/spiffs`
- * Specify your flash size in the Makefile `FLASH_SIZE = 32`
+ * Specify your flash size in the Makefile `FLASH_SIZE = 4`
  * Specify the start address of file system region on the flash memory
 `SPIFFS_BASE_ADDR = 0x200000`. It still needed even for `SPIFFS_SINGLETON = 0`
 in order to flash SPIFFS image to the right location during `make flash`.
@@ -42,7 +42,7 @@ In the end the Makefile should look like:
 ```
 PROGRAM=spiffs_example
 EXTRA_COMPONENTS = extras/spiffs
-FLASH_SIZE = 32
+FLASH_SIZE = 4
 
 SPIFFS_BASE_ADDR = 0x200000
 SPIFFS_SIZE = 0x100000

--- a/parameters.mk
+++ b/parameters.mk
@@ -10,7 +10,7 @@
 
 # Flash size in megabits
 # Valid values are same as for esptool.py - 2,4,8,16,32
-FLASH_SIZE ?= 16
+FLASH_SIZE ?= 2
 
 # Flash mode, valid values are same as for esptool.py - qio,qout,dio.dout
 FLASH_MODE ?= qio
@@ -30,7 +30,7 @@ ESPPORT ?= /dev/ttyUSB0
 ESPBAUD ?= 115200
 
 # firmware tool arguments
-ESPTOOL_ARGS=-fs $(FLASH_SIZE)m -fm $(FLASH_MODE) -ff $(FLASH_SPEED)m
+ESPTOOL_ARGS=-fs $(FLASH_SIZE)MB -fm $(FLASH_MODE) -ff $(FLASH_SPEED)m
 
 
 # set this to 0 if you don't need floating point support in printf/scanf

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ EXTRA_COMPONENTS=extras/dhcpserver extras/spiffs
 
 PROGRAM_SRC_DIR = . ./cases
 
-FLASH_SIZE = 32
+FLASH_SIZE = 4
 
 # spiffs configuration
 SPIFFS_BASE_ADDR = 0x200000


### PR DESCRIPTION
When building I noticed the warning, "WARNING: Flash size arguments in megabits like '16m' are deprecated." This should take care of that.