### PR TITLE
lwip update

### DIFF
--- a/core/app_main.c
+++ b/core/app_main.c
@@ -373,16 +373,22 @@ void sdk_user_init_task(void *params) {
     sdk_wifi_mode_set(sdk_g_ic.s.wifi_mode);
     if (sdk_g_ic.s.wifi_mode == STATION_MODE) {
         sdk_wifi_station_start();
+        LOCK_TCPIP_CORE();
         netif_set_default(sdk_g_ic.v.station_netif_info->netif);
+        UNLOCK_TCPIP_CORE();
     }
     if (sdk_g_ic.s.wifi_mode == SOFTAP_MODE) {
         sdk_wifi_softap_start();
+        LOCK_TCPIP_CORE();
         netif_set_default(sdk_g_ic.v.softap_netif_info->netif);
+        UNLOCK_TCPIP_CORE();
     }
     if (sdk_g_ic.s.wifi_mode == STATIONAP_MODE) {
         sdk_wifi_station_start();
         sdk_wifi_softap_start();
+        LOCK_TCPIP_CORE();
         netif_set_default(sdk_g_ic.v.station_netif_info->netif);
+        UNLOCK_TCPIP_CORE();
     }
     if (sdk_wifi_station_get_auto_connect()) {
         sdk_wifi_station_connect();

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -1689,7 +1689,9 @@ static void server_task(void *pvParameters)
         struct netif *softap_netif = sdk_system_get_netif(SOFTAP_IF);
         if ((wifi_sta_mdns && station_netif) || (wifi_ap_mdns && softap_netif)) {
 #if LWIP_MDNS_RESPONDER
+            LOCK_TCPIP_CORE();
             mdns_resp_init();
+            UNLOCK_TCPIP_CORE();
 #endif
 #if EXTRAS_MDNS_RESPONDER
             mdns_init();
@@ -1697,16 +1699,22 @@ static void server_task(void *pvParameters)
 #endif
         }
 #if LWIP_MDNS_RESPONDER
+        LOCK_TCPIP_CORE();
         if (wifi_sta_mdns && station_netif) {
+            LOCK_TCPIP_CORE();
             mdns_resp_add_netif(station_netif, hostname, 120);
             mdns_resp_add_service(station_netif, hostname, "_http",
                                   DNSSD_PROTO_TCP, 80, 3600, NULL, NULL);
+            UNLOCK_TCPIP_CORE();
         }
         if (wifi_ap_mdns && softap_netif) {
+            LOCK_TCPIP_CORE();
             mdns_resp_add_netif(softap_netif, hostname, 120);
             mdns_resp_add_service(softap_netif, hostname, "_http",
                                   DNSSD_PROTO_TCP, 80, 3600, NULL, NULL);
+            UNLOCK_TCPIP_CORE();
         }
+        UNLOCK_TCPIP_CORE();
 #endif
 
         free(hostname);
@@ -2233,10 +2241,6 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
         params->dispatch = dispatch;
 
         size_t stack_size = 464;
-#if LWIP_MDNS_RESPONDER
-        /* Uses a lot of stack space, so allocate extra. */
-        stack_size += 128;
-#endif
         xTaskCreate(server_task, "WiFi Cfg HTTP", stack_size, params, 2, NULL);
     }
 }

--- a/lwip/include/arch/cc.h
+++ b/lwip/include/arch/cc.h
@@ -87,14 +87,9 @@ typedef int sys_prot_t;
     } while(0)
 #define LWIP_PLATFORM_ASSERT(x) do { printf("Assertion \"%s\" failed at line %d in %s\n", \
                                             x, __LINE__, __FILE__); abort(); } while(0)
-
-#define LWIP_ERROR(message, expression, handler) do { if (!(expression)) { \
-  printf("Assertion \"%s\" failed at line %d in %s\n", message, __LINE__, __FILE__); \
-  handler;} } while(0)
 #else
 #define LWIP_PLATFORM_DIAG(x)
 #define LWIP_PLATFORM_ASSERT(x)
-#define LWIP_ERROR(m,e,h)
 #endif
 
 #define LWIP_PLATFORM_BYTESWAP 1
@@ -103,5 +98,8 @@ typedef int sys_prot_t;
 #define LWIP_PLATFORM_HTONL(_n)  ((u32_t)( (((_n) & 0xff) << 24) | (((_n) & 0xff00) << 8) | (((_n) >> 8)  & 0xff00) | (((_n) >> 24) & 0xff) ))
 
 #define LWIP_RAND()                         hwrand()
+
+/* Newlib includes this definition so use it. */
+#define lwip_strnstr(buffer, token, n) strnstr(buffer, token, n)
 
 #endif /* __ARCH_CC_H__ */

--- a/lwip/include/arch/sys_arch.h
+++ b/lwip/include/arch/sys_arch.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
- * All rights reserved. 
+ * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without modification, 
  * are permitted provided that the following conditions are met:
@@ -53,6 +53,10 @@ typedef TaskHandle_t sys_thread_t;
 #define sys_sem_valid( x ) ( ( ( *x ) == NULL) ? pdFALSE : pdTRUE )
 #define sys_sem_set_invalid( x ) ( ( *x ) = NULL )
 
+#define sys_jiffies() xTaskGetTickCount()
+
+void sys_arch_msleep(uint32_t ms);
+#define sys_msleep(ms) sys_arch_msleep(ms)
 
 #endif /* __ARCH_SYS_ARCH_H__ */
 

--- a/lwip/include/lwipopts.h
+++ b/lwip/include/lwipopts.h
@@ -81,7 +81,9 @@
  * UNLOCK_TCPIP_CORE().
  * Your system should provide mutexes supporting priority inversion to use this.
  */
+#ifndef LWIP_TCPIP_CORE_LOCKING
 #define LWIP_TCPIP_CORE_LOCKING         1
+#endif
 
 /**
  * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
@@ -94,6 +96,48 @@
 #ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
 #define LWIP_TCPIP_CORE_LOCKING_INPUT   0
 #endif
+
+/**
+ * Macro/function to check whether lwIP's threading/locking
+ * requirements are satisfied during current function call.
+ * This macro usually calls a function that is implemented in the OS-dependent
+ * sys layer and performs the following checks:
+ * - Not in ISR
+ * - If @ref LWIP_TCPIP_CORE_LOCKING = 1: TCPIP core lock is held
+ * - If @ref LWIP_TCPIP_CORE_LOCKING = 0: function is called from TCPIP thread
+ * @see @ref multithreading
+ */
+#ifndef LWIP_ASSERT_CORE_LOCKED
+void sys_check_core_locking(void);
+#define LWIP_ASSERT_CORE_LOCKED()       sys_check_core_locking()
+#endif
+
+/**
+ * Called as first thing in the lwIP TCPIP thread. Can be used in conjunction
+ * with @ref LWIP_ASSERT_CORE_LOCKED to check core locking.
+ * @see @ref multithreading
+ */
+#ifndef LWIP_MARK_TCPIP_THREAD
+void sys_mark_tcpip_thread(void);
+#define LWIP_MARK_TCPIP_THREAD()        sys_mark_tcpip_thread()
+#endif
+
+#if LWIP_TCPIP_CORE_LOCKING
+
+#ifndef LOCK_TCPIP_CORE
+void sys_lock_tcpip_core(void);
+#define LOCK_TCPIP_CORE()          sys_lock_tcpip_core()
+#endif
+
+#ifndef UNLOCK_TCPIP_CORE
+void sys_unlock_tcpip_core(void);
+#define UNLOCK_TCPIP_CORE()        sys_unlock_tcpip_core()
+#endif
+
+#else
+#define LOCK_TCPIP_CORE()
+#define UNLOCK_TCPIP_CORE()
+#endif /* LWIP_TCPIP_CORE_LOCKING */
 
 /*
    ------------------------------------
@@ -484,6 +528,21 @@
 #endif
 
 /**
+ * LWIP_NETIF_API==1: Support netif api (in netifapi.c)
+ */
+#ifndef LWIP_NETIF_API
+#define LWIP_NETIF_API                  0
+#endif
+
+/**
+ * LWIP_NETIF_STATUS_CALLBACK==1: Support a callback function whenever an interface
+ * changes its up/down status (i.e., due to DHCP IP acquisition)
+ */
+#ifndef LWIP_NETIF_STATUS_CALLBACK
+#define LWIP_NETIF_STATUS_CALLBACK      0
+#endif
+
+/**
  * LWIP_NETIF_TX_SINGLE_PBUF: if this is set to 1, lwIP *tries* to put all data
  * to be sent into one single pbuf. This is for compatibility with DMA-enabled
  * MACs that do not support scatter-gather.
@@ -515,7 +574,7 @@
  * sys_thread_new() when the thread is created.
  */
 #ifndef TCPIP_THREAD_STACKSIZE
-#define TCPIP_THREAD_STACKSIZE          768
+#define TCPIP_THREAD_STACKSIZE          480
 #endif
 
 /**
@@ -671,6 +730,20 @@
    ---------- Hook options ---------------
    ---------------------------------------
 */
+
+/*
+   ---------------------------------------
+   ---------- mDNS options ---------------
+   ---------------------------------------
+*/
+
+/**
+ * LWIP_MDNS_RESPONDER_QUEUE_ANNOUNCEMENTS==1: Unsolicited announcements are
+ * queued and run from a timer callback.
+ */
+#ifndef LWIP_MDNS_RESPONDER_QUEUE_ANNOUNCEMENTS
+#define LWIP_MDNS_RESPONDER_QUEUE_ANNOUNCEMENTS     1
+#endif
 
 /*
    ---------------------------------------
@@ -854,6 +927,11 @@
  * IP6_DEBUG: Enable debugging for IPv6.
  */
 #define IP6_DEBUG                       LWIP_DBG_OFF
+
+/**
+ * MDNS_DEBUG: Enable debugging for multicast DNS.
+ */
+#define MDNS_DEBUG                      LWIP_DBG_OFF
 
 /*
    --------------------------------------------------

--- a/open_esplibs/libnet80211/ieee80211_hostap.c
+++ b/open_esplibs/libnet80211/ieee80211_hostap.c
@@ -216,13 +216,17 @@ bool sdk_wifi_softap_start() {
          struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
          netif_info->netif = netif;
          memcpy(&netif->hwaddr, mac_addr, 6);
+         LOCK_TCPIP_CORE();
          netif_add(netif, &sdk_info.softap_ipaddr, &sdk_info.softap_netmask,
                    &sdk_info.softap_gw, netif_info, ethernetif_init, tcpip_input);
+         UNLOCK_TCPIP_CORE();
      }
 
     sdk_ic_set_vif(1, 1, mac_addr, 1, 0);
 
+    LOCK_TCPIP_CORE();
     netif_set_up(netif_info->netif);
+    UNLOCK_TCPIP_CORE();
 
     if (sdk_wifi_get_opmode() != 3 ||
         !sdk_g_ic.v.station_netif_info ||
@@ -293,7 +297,9 @@ bool sdk_wifi_softap_stop() {
         } while (count < end);
     }
 
+    LOCK_TCPIP_CORE();
     netif_set_down(netif_info->netif);
+    UNLOCK_TCPIP_CORE();
     sdk_TmpSTAAPCloseAP = 1;
     sdk_ets_timer_disarm(&hostap_timer);
     sdk_ic_bss_info_update(1, &sdk_info.softap_mac_addr, 2, 0);

--- a/open_esplibs/libnet80211/ieee80211_sta.c
+++ b/open_esplibs/libnet80211/ieee80211_sta.c
@@ -42,7 +42,10 @@ bool sdk_wifi_station_start() {
             struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
             netif_info->netif = netif;
             memcpy(&netif->hwaddr, &sdk_info.sta_mac_addr, 6);
-            netif_add(netif, &sdk_info.sta_ipaddr, &sdk_info.sta_netmask, &sdk_info.sta_gw, netif_info, ethernetif_init, tcpip_input);
+            LOCK_TCPIP_CORE();
+            netif_add(netif, &sdk_info.sta_ipaddr, &sdk_info.sta_netmask,
+                      &sdk_info.sta_gw, netif_info, ethernetif_init, tcpip_input);
+            UNLOCK_TCPIP_CORE();
             sdk_wpa_attach(&sdk_g_ic);
         }
         sdk_ic_set_vif(0, 1, &sdk_info.sta_mac_addr, 0, 0);

--- a/open_esplibs/libnet80211/wl_cnx.c
+++ b/open_esplibs/libnet80211/wl_cnx.c
@@ -24,8 +24,10 @@ extern void *sdk_g_cnx_probe_rc_list_cb;
  */
 void dhcp_if_down(struct netif *netif)
 {
+    LOCK_TCPIP_CORE();
     dhcp_release_and_stop(netif);
     netif_set_down(netif);
+    UNLOCK_TCPIP_CORE();
 }
 
 struct sdk_cnx_node *sdk_cnx_rc_search(uint8_t *hwaddr) {

--- a/open_esplibs/libwpa/wpa_main.c
+++ b/open_esplibs/libwpa/wpa_main.c
@@ -97,8 +97,10 @@ void sdk_eagle_auth_done() {
 
     if (sdk_dhcpc_flag != DHCP_STOPPED) {
         printf("dhcp client start...\n");
+        LOCK_TCPIP_CORE();
         netif_set_up(netif);
         dhcp_start(netif);
+        UNLOCK_TCPIP_CORE();
         return;
     }
 
@@ -107,8 +109,10 @@ void sdk_eagle_auth_done() {
         return;
     }
 
+    LOCK_TCPIP_CORE();
     netif_set_addr(netif, &sdk_info.sta_ipaddr, &sdk_info.sta_netmask, &sdk_info.sta_gw);
     netif_set_up(netif);
+    UNLOCK_TCPIP_CORE();
     sdk_system_station_got_ip_set(ip_2_ip4(&netif->ip_addr),
                                   ip_2_ip4(&netif->netmask),
                                   ip_2_ip4(&netif->gw));


### PR DESCRIPTION
* The mdns resolver has been reworked to lower stack and memory usage. It received good feedback from upstream but was unfortunately not accepted as the change uses malloc'ed memory and the upstream lwip wishes to work with pools and without using malloc. The high stack usage was a big problem for esp-open-rtos, so we might have to maintain the differences for now.

* Improved lwip core locking, and lock checking. Upstream improvements, that need some added support from esp-open-rtos specific code. Move core lock is performed when calling from the esp-open-rtos code now, so a little safer. The checking is not enforced, but project might see warning messages and might want to look into them.

* The esp-open-rtos lwip support has been sync'ed with the new freertos port included with lwip. There are still some differences, but both appear to have benefited from this effort and the differences are smaller.

* A few lwip timer bugs have been resolved. This might help resolve some issues.

* Plus it picks up all the other upstream fixes and improvements.
