### PR TITLE
Add makefile flash hooks

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -244,11 +244,15 @@ $(FW_FILE): $(PROGRAM_OUT) $(FIRMWARE_DIR)
 	$(Q) $(ESPTOOL) elf2image --version=2 $(ESPTOOL_ARGS) $< -o $(FW_FILE)
 
 flash: all
+	$(if will_flash, $(call will_flash, "flash"))
 	$(ESPTOOL) -p $(ESPPORT) --baud $(ESPBAUD) write_flash $(ESPTOOL_ARGS) \
 		0x0 $(RBOOT_BIN) 0x1000 $(RBOOT_CONF) 0x2000 $(FW_FILE) $(SPIFFS_ESPTOOL_ARGS)
+	$(if did_flash, $(call did_flash, "flash"))
 
 erase_flash:
+	$(if will_flash, $(call will_flash, "erase"))
 	$(ESPTOOL) -p $(ESPPORT) --baud $(ESPBAUD) erase_flash
+	$(if did_flash, $(call did_flash, "erase"))
 
 size: $(PROGRAM_OUT)
 	$(Q) $(CROSS)size --format=sysv $(PROGRAM_OUT)


### PR DESCRIPTION
Every time I update I find that I'm editing common.mk to fix my terminal program. With this PR, I can just stick functions in local.mk (which is in .gitignore) like so:

    define will_flash
        @echo About to flash, fix terminal program, etc.
    endef

    define did_flash
        @echo Flash finished, clean up.
    endef

It might even be possible to determine the exit status of esptool to pass as an argument, but it's not necessary for me. 