### PR TITLE
Allow overriding bootloader flash arguments

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -246,7 +246,7 @@ $(FW_FILE): $(PROGRAM_OUT) $(FIRMWARE_DIR)
 flash: all
 	$(if will_flash, $(call will_flash, "flash"))
 	$(ESPTOOL) -p $(ESPPORT) --baud $(ESPBAUD) write_flash $(ESPTOOL_ARGS) \
-		0x0 $(RBOOT_BIN) 0x1000 $(RBOOT_CONF) 0x2000 $(FW_FILE) $(SPIFFS_ESPTOOL_ARGS)
+		$(RBOOT_ARGS) 0x2000 $(FW_FILE) $(SPIFFS_ESPTOOL_ARGS)
 	$(if did_flash, $(call did_flash, "flash"))
 
 erase_flash:

--- a/parameters.mk
+++ b/parameters.mk
@@ -130,6 +130,7 @@ CPPFLAGS += -DGITSHORTREV=$(GITSHORTREV)
 LINKER_SCRIPTS += $(ROOT)ld/program.ld $(ROOT)ld/rom.ld
 
 # rboot firmware binary paths for flashing
+RBOOT_ARGS ?= 0x0 $(RBOOT_BIN) 0x1000 $(RBOOT_CONF)
 RBOOT_BIN = $(ROOT)bootloader/firmware/rboot.bin
 RBOOT_PREBUILT_BIN = $(ROOT)bootloader/firmware_prebuilt/rboot.bin
 RBOOT_CONF = $(ROOT)bootloader/firmware_prebuilt/blank_config.bin


### PR DESCRIPTION
This just pulls out the rboot arguments into a separate variable to allow overriding `RBOOT_ARGS` in local.mk or an application's makefile.

I have several different flash arrangements and rewriting the bootloader with different SPI schemes (DIO, QIO, 4m, 8m, etc) breaks things. Instead of changing `FLASH_SIZE`, `FLASH_MODE`, and `FLASH_SPEED` each time a different chip is flashed, overriding `RBOOT_ARGS` to be blank allows an application to write a custom bootloader (maybe without rboot's config at 0x1000) or none at all.