### PR TITLE
Multi-Channel Soft PWM library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "extras/libesphttpd/libesphttpd/lib/heatshrink"]
 	path = extras/libesphttpd/libesphttpd/lib/heatshrink
 	url = https://github.com/atomicobject/heatshrink
+[submodule "extras/multipwm"]
+	path = extras/multipwm
+	url = https://github.com/nochkin/multipwm

--- a/examples/multipwm/Makefile
+++ b/examples/multipwm/Makefile
@@ -1,0 +1,4 @@
+# Simple makefile for multipwm example
+PROGRAM=multipwm_test
+EXTRA_COMPONENTS = extras/multipwm
+include ../../common.mk

--- a/examples/multipwm/multipwm_test.c
+++ b/examples/multipwm/multipwm_test.c
@@ -1,0 +1,50 @@
+/* An example for the multipwm library
+ * Connect LEDs to pins 12, 13, 15 to see the light changes
+ *
+ * Part of esp-open-rtos
+ * Copyright (c) Sashka Nochkin (https://github.com/nochkin)
+ * MIT Licensed
+ */
+
+#include "espressif/esp_common.h"
+#include "esp/uart.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "multipwm.h"
+
+void multipwm_task(void *pvParameters)
+{
+    uint32_t counts[] = {500, 2100, 3000};
+    int32_t   steps[] = {100,  300,  200};
+    uint8_t    pins[] = { 12,   13,   15};
+
+    pwm_info_t pwm_info;
+    pwm_info.channels = 3;
+
+    multipwm_init(&pwm_info);
+    for (uint8_t ii=0; ii<pwm_info.channels; ii++) {
+        multipwm_set_pin(&pwm_info, ii, pins[ii]);
+    }
+
+    while(1) {
+        multipwm_stop(&pwm_info);
+        for (uint8_t ii=0; ii<pwm_info.channels; ii++) {
+            multipwm_set_duty(&pwm_info, ii, counts[ii]);
+            counts[ii] += steps[ii];
+            if ((counts[ii] >= 10000) || (counts[ii] == 0)) {
+                steps[ii] = -steps[ii];
+            }
+        }
+        multipwm_start(&pwm_info);
+        vTaskDelay(1);
+    }
+}
+
+void user_init(void)
+{
+    uart_set_baud(0, 115200);
+    printf("SDK version:%s\n", sdk_system_get_sdk_version());
+
+    xTaskCreate(multipwm_task, "multipwm", 256, NULL, 2, NULL);
+}


### PR DESCRIPTION
This is the soft PWM library with the support of independent multiple channels.
As per [Issue 568](https://github.com/SuperHouse/esp-open-rtos/issues/568) I think it makes more sense to add it as a separate library to avoid potential issues with the existing projects where the original single-channel PWM library is being used already.

I added the correspondent example as well.
