### PR TITLE
i2c: revise timing calculation

### DIFF
--- a/extras/i2c/i2c.h
+++ b/extras/i2c/i2c.h
@@ -66,9 +66,7 @@ typedef enum
   I2C_FREQ_600K,
   I2C_FREQ_800K,
   I2C_FREQ_1000K,
-#if I2C_USE_GPIO16 == 0
   I2C_FREQ_1300K
-#endif
 } i2c_freq_t;
 
 /**
@@ -94,11 +92,29 @@ typedef struct i2c_dev
 int i2c_init(uint8_t bus, uint8_t scl_pin, uint8_t sda_pin, i2c_freq_t freq);
 
 /**
+ * Init bitbanging I2C driver on given pins
+ * @param bus Bus i2c selection
+ * @param scl_pin SCL pin for I2C
+ * @param sda_pin SDA pin for I2C
+ * @param freq frequency of bus in hertz
+ * @param clk_stretch I2C clock stretch. I2C_DEFAULT_CLK_STRETCH would be good in most cases
+ * @return Non-zero if error occured
+ */
+int i2c_init_hz(uint8_t bus, uint8_t scl_pin, uint8_t sda_pin, uint32_t freq);
+
+/**
  * Change bus frequency
  * @param bus Bus i2c selection
  * @param freq frequency of bus (ex : I2C_FREQ_400K)
  */
-void i2c_set_frequency(uint8_t bus, i2c_freq_t freq);
+int i2c_set_frequency(uint8_t bus, i2c_freq_t freq);
+
+/**
+ * Change bus frequency
+ * @param bus Bus i2c selection
+ * @param freq frequency of bus in hertz
+ */
+int i2c_set_frequency_hz(uint8_t bus, uint32_t freq);
 
 /**
  * Change clock stretch


### PR DESCRIPTION
Look-up tables were used for determining the delay loop counts before.
Based on these hand-tuned values, the loop overhead was estimated for
each option -- 80 and 160 MHz, fast and slow GPIO access. Instead of the
great number of tunable parameters one now only has to tune the overhead
values if the code is changed.

Functions were added to the API which allow setting an arbitrary
frequency. API backward compatibility is retained.