### PR TITLE
newlib: skip locking when within the NMI Irq.

### DIFF
--- a/core/newlib_syscalls.c
+++ b/core/newlib_syscalls.c
@@ -303,6 +303,10 @@ void _lock_acquire(_lock_t *lock) {
 
 void _lock_acquire_recursive(_lock_t *lock) {
     if (locks_initialized) {
+        if (sdk_NMIIrqIsOn) {
+            uart_putc(0, ':');
+            return;
+        }
         xSemaphoreTakeRecursive((QueueHandle_t)*lock, portMAX_DELAY);
     }
 }
@@ -321,6 +325,9 @@ void _lock_release(_lock_t *lock) {
 
 void _lock_release_recursive(_lock_t *lock) {
     if (locks_initialized) {
+        if (sdk_NMIIrqIsOn) {
+            return;
+        }
         xSemaphoreGiveRecursive((QueueHandle_t)*lock);
     }
 }


### PR DESCRIPTION
NMI Irq error paths call into printf which will use the newlib locks but these can not be used within the NMI, a task switch can not occur here. This case would be a terminal error path that is attempting to write some debug message in the process, so just bail out of the locking in this case. As a warning a ':' character is emitted and this will typically prefix lines emitted in this context - it would be an error for this path to be take in normal operation.