### PR TITLE
uart: add ability to configure byte length

### DIFF
--- a/core/include/esp/uart.h
+++ b/core/include/esp/uart.h
@@ -160,4 +160,14 @@ static inline UART_Parity uart_get_parity(int uart_num) {
     return (UART_Parity)((UART(uart_num).CONF0 & UART_CONF0_PARITY) != 0);
 }
 
+/* Set uart data bits length to the desired value */
+static inline void uart_set_byte_length(int uart_num, UART_ByteLength byte_length) {
+    UART(uart_num).CONF0 = SET_FIELD(UART(uart_num).CONF0, UART_CONF0_BYTE_LEN, byte_length);
+}
+
+/* Returns the current data bits length for the UART */
+static inline UART_ByteLength uart_get_byte_length(int uart_num) {
+    return (UART_ByteLength)(FIELD2VAL(UART_CONF0_BYTE_LEN, UART(uart_num).CONF0));
+}
+
 #endif /* _ESP_UART_H */

--- a/core/include/esp/uart_regs.h
+++ b/core/include/esp/uart_regs.h
@@ -62,6 +62,13 @@ typedef enum {
     UART_PARITY_ODD = 0b1
 } UART_Parity;
 
+typedef enum {
+    UART_BYTELENGTH_5 = 0b00,
+    UART_BYTELENGTH_6 = 0b01,
+    UART_BYTELENGTH_7 = 0b10,
+    UART_BYTELENGTH_8 = 0b11,
+} UART_ByteLength;
+
 /* Details for FIFO register */
 
 #define UART_FIFO_DATA_M  0x000000ff


### PR DESCRIPTION
This patch to optionally change data bits length of serial bus.

Signed-off-by: Jean-Nicolas Graux <nicogrx@gmail.com>