### PR TITLE
Deleted the definition fo HD44780_I2C

### DIFF
--- a/extras/hd44780/hd44780.h
+++ b/extras/hd44780/hd44780.h
@@ -11,9 +11,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef HD44780_I2C
-#define HD44780_I2C 1
-#endif
+//#ifndef HD44780_I2C
+//#define HD44780_I2C 1
+//#endif
 #if (HD44780_I2C)
 #include <i2c/i2c.h>
 #endif


### PR DESCRIPTION
There is no reason of the following 3 lines:
```
#ifndef HD44780_I2C
#define HD44780_I2C 1
#endif
```
They actually conflict with the option _HD44780_I2C = 0_ on the esp8266/esp-open-rtos/examples/hd44780_lcd/Makefile.

On the other hand if no option is added to the Makefile, the component.mk file on folder /esp8266/esp-open-rtos/extras/hd44780 declares it as:
HD44780_I2C ?= 1

As such there is no issue totally deleting these 3 lines.