### PR TITLE
Skip calling wrappers from a number of the ROM functions.

### DIFF
--- a/ld/rom.ld
+++ b/ld/rom.ld
@@ -57,18 +57,18 @@ PROVIDE ( __umoddi3 = 0x4000d770 );
 PROVIDE ( __umodsi3 = 0x4000e268 );
 PROVIDE ( __umulsidi3 = 0x4000dcf0 );
 
-PROVIDE ( bzero = 0x40002ae8 );
-PROVIDE ( memcmp = 0x400018d4 );
-PROVIDE ( memcpy = 0x400018b4 );
-PROVIDE ( memmove = 0x400018c4 );
-PROVIDE ( memset = 0x400018a4 );
+PROVIDE ( bzero = 0x4000de84 );
+PROVIDE ( memcmp = 0x4000dea8 );
+PROVIDE ( memcpy = 0x4000df48 );
+PROVIDE ( memmove = 0x4000e04c );
+PROVIDE ( memset = 0x4000e190 );
 
-PROVIDE ( strcmp = 0x40002aa8 );
-PROVIDE ( strcpy = 0x40002a88 );
-PROVIDE ( strlen = 0x40002ac8 );
-PROVIDE ( strncmp = 0x40002ab8 );
-PROVIDE ( strncpy = 0x40002a98 );
-PROVIDE ( strstr = 0x40002ad8 );
+PROVIDE ( strcmp = 0x4000bdc8 );
+PROVIDE ( strcpy = 0x4000bec8 );
+PROVIDE ( strlen = 0x4000bf4c );
+PROVIDE ( strncmp = 0x4000bfa8 );
+PROVIDE ( strncpy = 0x4000c0a0 );
+PROVIDE ( strstr = 0x4000e1e0 );
 
 PROVIDE ( ETS_INTR_LOCK = 0x40000f74 );
 PROVIDE ( ETS_INTR_UNLOCK = 0x40000f80 );


### PR DESCRIPTION
A number of the ROM functions were pointing to wrappers that saved and restored the $a0 register, but the functions they called either did not use $a0 or saved and restored $a0 as needed anyway.