### PR TITLE
FreeRTOS: Update to r2536.

### DIFF
--- a/FreeRTOS/Source/include/FreeRTOS.h
+++ b/FreeRTOS/Source/include/FreeRTOS.h
@@ -826,6 +826,13 @@ extern "C" {
 	#define configSTACK_DEPTH_TYPE uint16_t
 #endif
 
+#ifndef configMESSAGE_BUFFER_LENGTH_TYPE
+	/* Defaults to size_t for backward compatibility, but can be overridden
+	in FreeRTOSConfig.h if lengths will always be less than the number of bytes
+	in a size_t. */
+	#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
+#endif
+
 /* Sanity check the configuration. */
 #if( configUSE_TICKLESS_IDLE != 0 )
 	#if( INCLUDE_vTaskSuspend != 1 )
@@ -1019,7 +1026,7 @@ typedef struct xSTATIC_TCB
 		uint32_t 		ulDummy18;
 		uint8_t 		ucDummy19;
 	#endif
-	#if( ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) || ( portUSING_MPU_WRAPPERS == 1 ) )
+	#if( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 		uint8_t			uxDummy20;
 	#endif
 

--- a/FreeRTOS/Source/include/message_buffer.h
+++ b/FreeRTOS/Source/include/message_buffer.h
@@ -695,6 +695,25 @@ size_t xMessageBufferSpaceAvailable( MessageBufferHandle_t xMessageBuffer ) );
 
 /**
  * message_buffer.h
+ <pre>
+ size_t xMessageBufferNextLengthBytes( MessageBufferHandle_t xMessageBuffer ) );
+ </pre>
+ * Returns the length (in bytes) of the next message in a message buffer.
+ * Useful if xMessageBufferReceive() returned 0 because the size of the buffer
+ * passed into xMessageBufferReceive() was too small to hold the next message.
+ *
+ * @param xMessageBuffer The handle of the message buffer being queried.
+ *
+ * @return The length (in bytes) of the next message in the message buffer, or 0
+ * if the message buffer is empty.
+ *
+ * \defgroup xMessageBufferNextLengthBytes xMessageBufferNextLengthBytes
+ * \ingroup MessageBufferManagement
+ */
+#define xMessageBufferNextLengthBytes( xMessageBuffer ) xStreamBufferNextMessageLengthBytes( ( StreamBufferHandle_t ) xMessageBuffer ) PRIVILEGED_FUNCTION;
+
+/**
+ * message_buffer.h
  *
 <pre>
 BaseType_t xMessageBufferSendCompletedFromISR( MessageBufferHandle_t xStreamBuffer, BaseType_t *pxHigherPriorityTaskWoken );

--- a/FreeRTOS/Source/include/mpu_prototypes.h
+++ b/FreeRTOS/Source/include/mpu_prototypes.h
@@ -138,6 +138,7 @@ UBaseType_t MPU_uxEventGroupGetNumber( void* xEventGroup );
 size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer, const void *pvTxData, size_t xDataLengthBytes, TickType_t xTicksToWait );
 size_t MPU_xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer, const void *pvTxData, size_t xDataLengthBytes, BaseType_t * const pxHigherPriorityTaskWoken );
 size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer, void *pvRxData, size_t xBufferLengthBytes, TickType_t xTicksToWait );
+size_t MPU_xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer );
 size_t MPU_xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer, void *pvRxData, size_t xBufferLengthBytes, BaseType_t * const pxHigherPriorityTaskWoken );
 void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer );
 BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer );

--- a/FreeRTOS/Source/include/mpu_wrappers.h
+++ b/FreeRTOS/Source/include/mpu_wrappers.h
@@ -142,6 +142,7 @@ only for ports that are using the MPU. */
 		#define xStreamBufferSend						MPU_xStreamBufferSend
 		#define xStreamBufferSendFromISR				MPU_xStreamBufferSendFromISR
 		#define xStreamBufferReceive					MPU_xStreamBufferReceive
+		#define xStreamBufferNextMessageLengthBytes		MPU_xStreamBufferNextMessageLengthBytes
 		#define xStreamBufferReceiveFromISR				MPU_xStreamBufferReceiveFromISR
 		#define vStreamBufferDelete						MPU_vStreamBufferDelete
 		#define xStreamBufferIsFull						MPU_xStreamBufferIsFull

--- a/FreeRTOS/Source/include/queue.h
+++ b/FreeRTOS/Source/include/queue.h
@@ -233,7 +233,7 @@ typedef void * QueueSetMemberHandle_t;
 /**
  * queue. h
  * <pre>
- BaseType_t xQueueSendToToFront(
+ BaseType_t xQueueSendToFront(
 								   QueueHandle_t	xQueue,
 								   const void		*pvItemToQueue,
 								   TickType_t		xTicksToWait

--- a/FreeRTOS/Source/include/stream_buffer.h
+++ b/FreeRTOS/Source/include/stream_buffer.h
@@ -839,6 +839,8 @@ StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
 													   uint8_t * const pucStreamBufferStorageArea,
 													   StaticStreamBuffer_t * const pxStaticStreamBuffer ) PRIVILEGED_FUNCTION;
 
+size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;
+
 #if( configUSE_TRACE_FACILITY == 1 )
 	void vStreamBufferSetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer, UBaseType_t uxStreamBufferNumber ) PRIVILEGED_FUNCTION;
 	UBaseType_t uxStreamBufferGetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;

--- a/FreeRTOS/Source/include/task.h
+++ b/FreeRTOS/Source/include/task.h
@@ -135,7 +135,7 @@ typedef struct xTASK_STATUS
 	UBaseType_t uxBasePriority;		/* The priority to which the task will return if the task's current priority has been inherited to avoid unbounded priority inversion when obtaining a mutex.  Only valid if configUSE_MUTEXES is defined as 1 in FreeRTOSConfig.h. */
 	uint32_t ulRunTimeCounter;		/* The total run time allocated to the task so far, as defined by the run time stats clock.  See http://www.freertos.org/rtos-run-time-stats.html.  Only valid when configGENERATE_RUN_TIME_STATS is defined as 1 in FreeRTOSConfig.h. */
 	StackType_t *pxStackBase;		/* Points to the lowest address of the task's stack area. */
-	uint16_t usStackHighWaterMark;	/* The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */
+	configSTACK_DEPTH_TYPE usStackHighWaterMark;	/* The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */
 } TaskStatus_t;
 
 /* Possible return values for eTaskConfirmSleepModeStatus(). */

--- a/FreeRTOS/Source/list.c
+++ b/FreeRTOS/Source/list.c
@@ -114,7 +114,7 @@ const TickType_t xValueOfInsertion = pxNewListItem->xItemValue;
 	/* Insert the new list item into the list, sorted in xItemValue order.
 
 	If the list already contains a list item with the same item value then the
-	new list item should be placed after it.  This ensures that TCB's which are
+	new list item should be placed after it.  This ensures that TCBs which are
 	stored in ready lists (all of which have the same xItemValue value) get a
 	share of the CPU.  However, if the xItemValue is the same as the back marker
 	the iteration loop below will not end.  Therefore the value is checked

--- a/FreeRTOS/Source/tasks.c
+++ b/FreeRTOS/Source/tasks.c
@@ -509,7 +509,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait, const BaseT
  */
 #if ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) )
 
-	static uint16_t prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte ) PRIVILEGED_FUNCTION;
+	static configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte ) PRIVILEGED_FUNCTION;
 
 #endif
 
@@ -845,6 +845,8 @@ UBaseType_t x;
 		}
 		uxPriority &= ~portPRIVILEGE_BIT;
 	#endif /* portUSING_MPU_WRAPPERS == 1 */
+
+	configASSERT( pcName );
 
 	/* Avoid dependency on memset() if it is not required. */
 	#if( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 )
@@ -1982,7 +1984,7 @@ BaseType_t xReturn;
 
 		xNextTaskUnblockTime = portMAX_DELAY;
 		xSchedulerRunning = pdTRUE;
-		xTickCount = ( TickType_t ) 0U;
+		xTickCount = ( TickType_t ) configINITIAL_TICK_COUNT;
 
 		/* If configGENERATE_RUN_TIME_STATS is defined then the following
 		macro must be defined to configure the timer/counter used to generate
@@ -1991,6 +1993,8 @@ BaseType_t xReturn;
 		have portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() defined in your
 		FreeRTOSConfig.h file. */
 		portCONFIGURE_TIMER_FOR_RUN_TIME_STATS();
+
+		traceTASK_SWITCHED_IN();
 
 		/* Setting up the timer tick is hardware specific and thus in the
 		portable interface. */
@@ -2778,7 +2782,9 @@ BaseType_t xSwitchRequired = pdFALSE;
 		/* Save the hook function in the TCB.  A critical section is required as
 		the value can be accessed from an interrupt. */
 		taskENTER_CRITICAL();
+		{
 			xTCB->pxTaskTag = pxHookFunction;
+		}
 		taskEXIT_CRITICAL();
 	}
 
@@ -3474,7 +3480,7 @@ static void prvCheckTasksWaitingTermination( void )
 	{
 		TCB_t *pxTCB;
 
-		/* uxDeletedTasksWaitingCleanUp is used to prevent vTaskSuspendAll()
+		/* uxDeletedTasksWaitingCleanUp is used to prevent taskENTER_CRITICAL()
 		being called too often in the idle task. */
 		while( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U )
 		{
@@ -3625,7 +3631,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) )
 
-	static uint16_t prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
+	static configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
 	{
 	uint32_t ulCount = 0U;
 
@@ -3637,7 +3643,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 		ulCount /= ( uint32_t ) sizeof( StackType_t ); /*lint !e961 Casting is not redundant on smaller architectures. */
 
-		return ( uint16_t ) ulCount;
+		return ( configSTACK_DEPTH_TYPE ) ulCount;
 	}
 
 #endif /* ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) ) */


### PR DESCRIPTION
* Introduce sbBYTES_TO_STORE_MESSAGE_LENGTH

* Fix bug in ucStreamBufferGetStreamBufferType() - which is only used by the
  Percepio trace tool.

* Update the line within vTaskStartScheduler() that was setting xTickCount to 0
  to instead set it to configINITIAL_TICK_COUNT.

* Introduce xMessageBufferNextLengthBytes() and tests for the same.

* Add call to traceTASK_SWITCHED_IN() in vTaskStartScheduler() so trace tools
  can see the first task to run.

* Correct definition of StaticTask_t in the case that portUSE_MPU_WRAPPERS is
  set to 1.

* prvTaskCheckFreeStackSpace() now returns configSTACK_DEPTH_TYPE to allow
  return values greater than max uint16_t value if required.

* xStreamBufferSend() and xStreamBufferReceive() no longer clear task
  notification bits - clearing was unnecessary as only the task notification
  state is used.

* Correct out of date comment in tasks.c.

* Fix typo in comment in queue.h.