### PR TITLE
bugfix/ets_timer.c: race condition while disarming

### DIFF
--- a/open_esplibs/libmain/ets_timer.c
+++ b/open_esplibs/libmain/ets_timer.c
@@ -244,9 +244,9 @@ void sdk_ets_timer_disarm(ets_timer_t *timer)
         prev = curr;
         curr = curr->next;
     }
-    vPortExitCritical();
     timer->next = ETS_TIMER_NOT_ARMED;
     timer->period_ticks = 0;
+    vPortExitCritical();
 }
 
 /**


### PR DESCRIPTION
If `sdk_ets_timer_arm_ms_us` is called right after `vPortExitCritical` inside `sdk_ets_timer_disarm` on line 247 (by an ISR for example, which was my case), execution will loop forever on line 196, since `timer->next!=ETS_TIMER_NOT_ARMED`, which was supposed to be changed in line 248.
By delaying the IRS or context switch until `sdk_ets_timer_disarm` the problem is fixed.