### PR TITLE
sdk_wifi_station_dhcpc_stop: ensure the client is flagged as stopped.

### DIFF
--- a/open_esplibs/libmain/user_interface.c
+++ b/open_esplibs/libmain/user_interface.c
@@ -563,12 +563,12 @@ bool sdk_wifi_station_dhcpc_stop(void) {
     if (sdk_wifi_get_opmode() == 2) {
         return false;
     }
+    LOCK_TCPIP_CORE();
     if (netif && sdk_dhcpc_flag == DHCP_STARTED) {
-        LOCK_TCPIP_CORE();
         dhcp_stop(netif);
-        sdk_dhcpc_flag = DHCP_STOPPED;
-        UNLOCK_TCPIP_CORE();
     }
+    sdk_dhcpc_flag = DHCP_STOPPED;
+    UNLOCK_TCPIP_CORE();
     return true;
 }
 


### PR DESCRIPTION
Need to flag the dhcp client as stopped, even if the netif is not yet initialized, because the flag is used to control the starting of the dhcpc.