### PR TITLE
Improved C++ support, support C++ exceptions

### DIFF
--- a/core/cplusplus_operators.cpp
+++ b/core/cplusplus_operators.cpp
@@ -4,22 +4,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void *operator new(size_t size)
+void * __attribute__((weak)) operator new(size_t size)
 {
     return malloc(size);
 }
 
-void *operator new[](size_t size)
+void * __attribute__((weak)) operator new[](size_t size)
 {
     return malloc(size);
 }
 
-void operator delete(void * ptr)
+void __attribute__((weak)) operator delete(void * ptr)
 {
     free(ptr);
 }
 
-void operator delete[](void * ptr)
+void __attribute__((weak)) operator delete[](void * ptr)
 {
     free(ptr);
 }

--- a/ld/program.ld
+++ b/ld/program.ld
@@ -113,7 +113,11 @@ SECTIONS
     *libc.a:*bzero.o(.literal .text .literal.* .text.*)
     *libc.a:*lock.o(.literal .text .literal.* .text.*)
 
-    *libc.a:*printf.o(.literal .text .literal.* .text.*)
+    *libc.a:*-printf.o(.literal .text .literal.* .text.*)
+    *libc.a:*-sprintf.o(.literal .text .literal.* .text.*)
+    *libc.a:*-fprintf.o(.literal .text .literal.* .text.*)
+    *libc.a:*-svfprintf.o(.literal .text .literal.* .text.*)
+    *libc.a:*-vfprintf.o(.literal .text .literal.* .text.*)
     *libc.a:*findfp.o(.literal .text .literal.* .text.*)
     *libc.a:*fputwc.o(.literal .text .literal.* .text.*)
 

--- a/ld/program.ld
+++ b/ld/program.ld
@@ -253,10 +253,13 @@ SECTIONS
     *(.gnu.linkonce.r.*)
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     *(.xt_except_table)
-    *(.gcc_except_table)
+    *(.gcc_except_table .gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
-    *(.eh_frame)
+    . = (. + 3) & ~ 3;
+    __eh_frame = ABSOLUTE(.);
+    KEEP(*(.eh_frame))
+    . = (. + 7) & ~ 3;
     . = ALIGN(4);
     *(.dynamic)
     *(.gnu.version_d)


### PR DESCRIPTION
These patches make it possible to link against libstdc++, and use C++ exceptions.

To use c++ exceptions, build a gcc 5.2.0 toolchain from https://github.com/espressif/crosstool-NG
with -fexceptions and -frtti enabled. You can use my build script for mac:
[buildtoolchain.sh.zip](https://github.com/SuperHouse/esp-open-rtos/files/2009884/buildtoolchain.sh.zip)

Add the following startup code to your application:
```
struct register_frame_info_object { long placeholder[ 10 ]; };
extern "C" void __register_frame_info (const void *begin, struct register_frame_info_object *ob);
extern char __eh_frame[];

extern "C" void user_init()
{
	static struct register_frame_info_object ob;
	__register_frame_info( __eh_frame, &ob );

[...]
}

```
More info: 
https://github.com/jcmvbkbc/crosstool-NG/issues/54
https://github.com/espressif/esp-idf/issues/459
https://github.com/SuperHouse/esp-open-rtos/issues/623
