### PR TITLE
ssd1306: allow SPI3 to be disabled, compact device descriptor

### DIFF
--- a/extras/ssd1306/component.mk
+++ b/extras/ssd1306/component.mk
@@ -1,17 +1,19 @@
 # Component makefile for extras/ssd1306
 
 # expected anyone using ssd1306 driver includes it as 'ssd1306/ssd1306.h'
-INC_DIRS += $(ssd1306_ROOT)..
+INC_DIRS += $(ROOT)extras
 
 # I2C support is on by default
-SSD1306_I2C_SUPPORT ?= 1
+SSD1306_I2C_SUPPORT   ?= 1
 # SPI4 support is on by default
-SSD1306_SPI4_SUPPORT ?= 1
+SSD1306_SPI4_SUPPORT  ?= 1
+# SPI3 support is on by default
+SSD1306_SPI3_SUPPORT  ?= 1
 
 # args for passing into compile rule generation
 ssd1306_SRC_DIR = $(ssd1306_ROOT)
 
-ssd1306_CFLAGS = -DSSD1306_I2C_SUPPORT=${SSD1306_I2C_SUPPORT} -DSSD1306_SPI4_SUPPORT=${SSD1306_SPI4_SUPPORT} $(CFLAGS)
+ssd1306_CFLAGS = -DSSD1306_I2C_SUPPORT=${SSD1306_I2C_SUPPORT} -DSSD1306_SPI4_SUPPORT=${SSD1306_SPI4_SUPPORT} -DSSD1306_SPI3_SUPPORT=${SSD1306_SPI3_SUPPORT} $(CFLAGS)
 
 
 $(eval $(call component_compile_rules,ssd1306))

--- a/extras/ssd1306/ssd1306.h
+++ b/extras/ssd1306/ssd1306.h
@@ -64,8 +64,10 @@ typedef enum
  */
 typedef struct
 {
-    ssd1306_protocol_t protocol;
-    ssd1306_screen_t screen;
+    struct {
+        uint8_t protocol : 4;     //!< I/O protocol
+        uint8_t screen : 4;       //!< Screen type
+    };
 #if (SSD1306_I2C_SUPPORT)
     i2c_dev_t i2c_dev;            //!< I2C device descriptor, used by SSD1306_PROTO_I2C
 #endif

--- a/extras/ssd1306/ssd1306.h
+++ b/extras/ssd1306/ssd1306.h
@@ -66,15 +66,12 @@ typedef struct
 {
     ssd1306_protocol_t protocol;
     ssd1306_screen_t screen;
-    union
-    {
 #if (SSD1306_I2C_SUPPORT)
-        i2c_dev_t i2c_dev;         //!< I2C devuce descriptor, used by SSD1306_PROTO_I2C
+    i2c_dev_t i2c_dev;            //!< I2C device descriptor, used by SSD1306_PROTO_I2C
 #endif
 #if (SSD1306_SPI4_SUPPORT) || (SSD1306_SPI3_SUPPORT)
-        uint8_t cs_pin;            //!< Chip Select GPIO pin, used by SSD1306_PROTO_SPI3, SSD1306_PROTO_SPI4
+    uint8_t cs_pin;               //!< Chip Select GPIO pin, used by SSD1306_PROTO_SPI3, SSD1306_PROTO_SPI4
 #endif
-    };
 #if (SSD1306_SPI4_SUPPORT)
     uint8_t dc_pin;               //!< Data/Command GPIO pin, used by SSD1306_PROTO_SPI4
 #endif


### PR DESCRIPTION
I added SPI4W protocol to the driver. It is a flavor of the SPI4 protocol with HW driven CS and no MISO (pin is reconfigured as GPIO and used for D/C). That's how my device is wired :smile: Hopefully others will like this option too as it saves a GPIO pin (or two, depends on the counting method :smile: ) if one does not mind wiring CS and D/C to the predefined pins.

There are two additional small changes:
- Pass **all** SUPPORT macros to `CFLAGS`. This allows building the driver with only required protocols (probably just one),
- "Pack" device descriptor struct. This shrinks it by 7 bytes without any code changes needed on the program side.

The changed driver has been tested by compiling and running both ssd1306 examples - example and fps - on my device.