### PR TITLE
ssd1306: Reduce device descriptor size

### DIFF
--- a/extras/ssd1306/ssd1306.h
+++ b/extras/ssd1306/ssd1306.h
@@ -64,19 +64,16 @@ typedef enum
  */
 typedef struct
 {
-    ssd1306_protocol_t protocol;
-    ssd1306_screen_t screen;
-    union
-    {
-#if (SSD1306_I2C_SUPPORT)
-        i2c_dev_t i2c_dev;         //!< I2C devuce descriptor, used by SSD1306_PROTO_I2C
-#endif
+    ssd1306_protocol_t protocol : 2;
+    ssd1306_screen_t screen : 1;
 #if (SSD1306_SPI4_SUPPORT) || (SSD1306_SPI3_SUPPORT)
-        uint8_t cs_pin;            //!< Chip Select GPIO pin, used by SSD1306_PROTO_SPI3, SSD1306_PROTO_SPI4
+    uint8_t cs_pin : 5;           //!< Chip Select GPIO pin, used by SSD1306_PROTO_SPI3, SSD1306_PROTO_SPI4
 #endif
-    };
 #if (SSD1306_SPI4_SUPPORT)
     uint8_t dc_pin;               //!< Data/Command GPIO pin, used by SSD1306_PROTO_SPI4
+#endif
+#if (SSD1306_I2C_SUPPORT)
+    i2c_dev_t i2c_dev;            //!< I2C device descriptor, used by SSD1306_PROTO_I2C
 #endif
     uint8_t width;                //!< Screen width, currently supported 128px, 96px
     uint8_t height;               //!< Screen height, currently supported 16px, 32px, 64px


### PR DESCRIPTION
Presently, depending on the selected protocols, compiler allocates 12 or 16 bytes for the `ssd1306_t` struct. These changes shrink it to 4 or 8 bytes (8 bytes are needed with I2C present).

There are 3 individual changes in here:
- Protocol and screen enums are turned into bit fields,
- CS pin is also changed into a bit field and is moved, so it would be packed into 1 byte together with the protocol and the screen fields,
- Union is removed.

The biggest space hogs were the enums. Changing them into bit fields just to make sure they are packed into a byte:
```h
ssd1306_protocol_t protocol : 4;
ssd1306_screen_t screen : 4;
```
immediately reduced `ssd1306_t` to no more than 8 bytes (4 when only SPI3 support is selected).

The current use of the `union` seems superfluous, because when support for the I2C is included the absolute minimum required size for the `ssd1306_t`, with the enums packed, is 5 bytes, which turns into 8 allocated bytes with the compiler added padding. Without `union` the struct's payload will need 6 bytes, but as the allocation is still 8 the difference is only in how many padding bytes are used. And, IMHO, removing the `union` improves readability without sacrificing anything.

Changing `cs_pin` into a bit field allows not only SPI3, but also SPI4 to be as small as 4 bytes. The "penalty" for that is one instruction - EXTUI - that the compiler inserts to extract it.