### PR TITLE
add 'make help' hooks

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -275,6 +275,7 @@ clean:
 
 # print some useful help stuff
 help:
+	$(if will_help, $(call will_help))
 	@echo "esp-open-rtos make"
 	@echo ""
 	@echo "Other targets:"
@@ -304,5 +305,6 @@ help:
 	@echo "SAMPLE COMMAND LINE:"
 	@echo "make -j2 test ESPPORT=/dev/ttyUSB0"
 	@echo ""
+	$(if did_help, $(call did_help))
 
 


### PR DESCRIPTION
Projects can define will_help and/or did_help functions, which lets them
add additional help text (output of 'make help') before respectively
after the standard esp-open-rtos help text.