### PR TITLE
wificfg: add shutdown hooks, and add support to wait until connected.

### DIFF
--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -1375,6 +1375,45 @@ void wificfg_got_sta_connect()
     }
 }
 
+void wificfg_wait_until_sta_connected()
+{
+    while (1) {
+        uint8_t connect_status = sdk_wifi_station_get_connect_status();
+        if (connect_status == STATION_GOT_IP)
+            break;
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+
+    /*
+     * Notifty wificfg to disable the AP interface on the next restart
+     * if that option is enabled.
+     */
+    wificfg_got_sta_connect();
+}
+
+struct shutdown_hook {
+  struct shutdown_hook *next;
+  void (*fn)(void *);
+  void *arg;
+};
+
+static struct shutdown_hook *shutdown_hooks;
+
+bool wificfg_add_shutdown_hook(void (*fn)(void *), void *arg)
+{
+  struct shutdown_hook *hook = malloc(sizeof(struct shutdown_hook));
+
+  if (!hook) {
+    return false;
+  }
+
+  hook->next = shutdown_hooks;
+  hook->fn = fn;
+  hook->arg = arg;
+  shutdown_hooks = hook;
+  return true;
+}
+
 static int handle_restart_post(int s, wificfg_method method,
                                uint32_t content_length,
                                wificfg_content_type content_type,
@@ -1382,6 +1421,10 @@ static int handle_restart_post(int s, wificfg_method method,
 {
     wificfg_write_string(s, http_redirect_header);
     close(s);
+    struct shutdown_hook *hook;
+    for (hook = shutdown_hooks; hook; hook = hook->next) {
+      hook->fn(hook->arg);
+    }
     vTaskDelay(2000 / portTICK_PERIOD_MS);
     sdk_system_restart();
     return 0;

--- a/extras/wificfg/wificfg.h
+++ b/extras/wificfg/wificfg.h
@@ -121,11 +121,11 @@ ssize_t wificfg_write_chunk_end(int s);
 /* Write a html title meta data, using the hostname or AP SSI. */
 int wificfg_write_html_title(int s, char *buf, size_t len, const char *str);
 
-/* Callback to notify the wificfg logic that a station connection has been
- * successfully established. It might use this to disable the AP interface after
- * a restart.
- */
-void wificfg_got_sta_connect(void);
+/* Wait until the station interface has connected to an access point,
+ * and obtained an IP address. */
+void wificfg_wait_until_sta_connected(void);
+
+bool wificfg_add_shutdown_hook(void (*fn)(void *), void *arg);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Remove the wificfg_got_sta_connect() function and replace it with wificfg_wait_until_sta_connected(). This replaces a probe function with a wait function, and this better fits the wifi layer using an event model - the wait function can wait on a station connection event before returning. This helped get this working on the esp-idf framework - small steps in that direction.

The shutdown hooks are called when the wificfg restart function is used. It can be used to implement a cleaner restart, for example blocking further i2c and flash operations.