### PR TITLE
libmain: add a compile option to avoid saving wifi params to flash

### DIFF
--- a/examples/sysparam_editor/Makefile
+++ b/examples/sysparam_editor/Makefile
@@ -1,7 +1,10 @@
 PROGRAM=sysparam_editor
 
 # Setting this to 1..3 will add extra debugging output to stdout
-EXTRA_CFLAGS=-DSYSPARAM_DEBUG=0
+EXTRA_CFLAGS = -DSYSPARAM_DEBUG=0
+
+# Avoid writing the wifi state to flash when using wificfg.
+EXTRA_CFLAGS += -DWIFI_PARAM_SAVE=0
 
 include ../../common.mk
 

--- a/examples/wificfg/Makefile
+++ b/examples/wificfg/Makefile
@@ -3,10 +3,13 @@ PROGRAM=wificfg
 EXTRA_COMPONENTS=extras/dhcpserver extras/wificfg
 
 # For the mDNS responder included under extras:
-# EXTRA_COMPONENTS+=extras/mdnsresponder
-# EXTRA_CFLAGS=-DEXTRAS_MDNS_RESPONDER
+# EXTRA_COMPONENTS += extras/mdnsresponder
+# EXTRA_CFLAGS += -DEXTRAS_MDNS_RESPONDER
 
 # For the mDNS responder included with lwip:
-EXTRA_CFLAGS=-DLWIP_MDNS_RESPONDER=1 -DLWIP_NUM_NETIF_CLIENT_DATA=1 -DLWIP_NETIF_EXT_STATUS_CALLBACK=1
+EXTRA_CFLAGS += -DLWIP_MDNS_RESPONDER=1 -DLWIP_NUM_NETIF_CLIENT_DATA=1 -DLWIP_NETIF_EXT_STATUS_CALLBACK=1
+
+# Avoid writing the wifi state to flash when using wificfg.
+EXTRA_CFLAGS += -DWIFI_PARAM_SAVE=0
 
 include ../../common.mk


### PR DESCRIPTION
Add source code for sdk_wifi_param_save_protect() and a compile time, WIFI_PARAM_SAVE, option to skip writing the wifi state to flash. This avoids wear on the flash and does not appear to be necessary when the app initializes the state anyway.

Define WIFI_PARAM_SAVE to 0 for the wificfg example.