### PR TITLE
Shrink gpio<>iomux maps

### DIFF
--- a/core/esp_iomux.c
+++ b/core/esp_iomux.c
@@ -7,8 +7,8 @@
 #include "esp/iomux.h"
 #include "common_macros.h"
 
-const static IRAM_DATA uint32_t IOMUX_TO_GPIO[] = { 12, 13, 14, 15, 3, 1, 6, 7, 8, 9, 10, 11, 0, 2, 4, 5 };
-const static IRAM_DATA uint32_t GPIO_TO_IOMUX[] = { 12, 5, 13, 4, 14, 15, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3 };
+const static IRAM_DATA uint8_t IOMUX_TO_GPIO[] = { 12, 13, 14, 15, 3, 1, 6, 7, 8, 9, 10, 11, 0, 2, 4, 5 };
+const static IRAM_DATA uint8_t GPIO_TO_IOMUX[] = { 12, 5, 13, 4, 14, 15, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3 };
 
 uint8_t IRAM gpio_to_iomux(const uint8_t gpio_number)
 {


### PR DESCRIPTION
Both maps are in RAM, so there is really no need to allocate extra memory for each entry - no aligned reads.

The assembler for `gpio_to_iomux` and `iomux_to_gpio` differs only in how array entry address (offset) is calculated:
- current: `addx4 a2, a2, a3`
- changed: `add.n a2, a3, a2`
