### PR TITLE
Add ADS1015 support to ads111x lib.

### DIFF
--- a/extras/ads111x/ads111x.c
+++ b/extras/ads111x/ads111x.c
@@ -93,6 +93,18 @@ int16_t ads111x_get_value(i2c_dev_t *dev)
     return read_reg(dev, REG_CONVERSION);
 }
 
+int16_t ads101x_get_value(i2c_dev_t *dev)
+{
+	uint16_t res = read_reg(dev, REG_CONVERSION) >> 4;
+	if (res > 0x07FF)
+	{
+		// negative number - extend the sign to 16th bit
+		res |= 0xF000;
+	}
+	return (int16_t)res;
+}
+
+
 ads111x_gain_t ads111x_get_gain(i2c_dev_t *dev)
 {
     return read_conf_bits(dev, PGA_OFFSET, PGA_MASK);

--- a/extras/ads111x/ads111x.h
+++ b/extras/ads111x/ads111x.h
@@ -22,6 +22,16 @@ extern "C" {
 #define ADS111X_ADDR_SCL 0x4b
 
 #define ADS111X_MAX_VALUE 0x7fff
+#define ADS101X_MAX_VALUE 0x7ff
+
+// ADS101X overrides
+#define ADS101X_DATA_RATE_128  	ADS111X_DATA_RATE_8 
+#define ADS101X_DATA_RATE_250  	ADS111X_DATA_RATE_16
+#define ADS101X_DATA_RATE_490  	ADS111X_DATA_RATE_32
+#define ADS101X_DATA_RATE_920  	ADS111X_DATA_RATE_64
+#define ADS101X_DATA_RATE_1600	ADS111X_DATA_RATE_128
+#define ADS101X_DATA_RATE_2400	ADS111X_DATA_RATE_250
+#define ADS101X_DATA_RATE_3300	ADS111X_DATA_RATE_475
 
 /**
  * Gain amplifier
@@ -139,6 +149,13 @@ void ads111x_start_conversion(i2c_dev_t *dev);
  * @return Last conversion result
  */
 int16_t ads111x_get_value(i2c_dev_t *dev);
+
+/**
+ * Read last conversion result for 101x
+ * @param addr
+ * @return Last conversion result
+ */
+int16_t ads101x_get_value(i2c_dev_t *dev);
 
 /**
  * Read the programmable gain amplifier configuration


### PR DESCRIPTION
ADS101x is a faster version of ADS111x ADC, with lower precision.
This change provides basic support for device, by defining sample rates used by ADS101x and providing new ads101x_get_value() function with proper 4-bit shift to obtain actual ADC value.