### PR TITLE
added lease time option to dhcpserver's DHCPOFFER

### DIFF
--- a/extras/dhcpserver/dhcpserver.c
+++ b/extras/dhcpserver/dhcpserver.c
@@ -254,6 +254,9 @@ static void handle_dhcp_discover(struct dhcp_msg *dhcpmsg)
         opt = add_dhcp_option_bytes(opt, DHCP_OPTION_DNS_SERVER, &state->dns, 4);
     }
 
+    uint32_t expiry = htonl(DHCPSERVER_LEASE_TIME);
+    opt = add_dhcp_option_bytes(opt, DHCP_OPTION_LEASE_TIME, &expiry, 4);
+
     opt = add_dhcp_option_bytes(opt, DHCP_OPTION_END, NULL, 0);
 
     struct netbuf *netbuf = netbuf_new();


### PR DESCRIPTION
This adds `DHCP_OPTION_LEASE_TIME` to dhcpserver's DHCPOFFER which is required by [rfc2131](https://www.ietf.org/rfc/rfc2131.txt) (table 3, page 28). This fixes the server incompatibility with ISC dhclient (tested on version 4.4.1) which is standard dhcp client on arch.