### PR TITLE
Http download issue when connection lost

### DIFF
--- a/extras/http_client_ota/http_buffered_client.c
+++ b/extras/http_client_ota/http_buffered_client.c
@@ -208,8 +208,6 @@ HTTP_Client_State HttpClient_dowload(Http_client_info *info)
             full    = 0;
             vTaskDelayMs(50);
         }
-
-        //printf("Download size read data : %d\n", read_byte);
     } while (read_byte > 0);
 
     info->final_cb(info->buffer, full);

--- a/extras/http_client_ota/http_buffered_client.c
+++ b/extras/http_client_ota/http_buffered_client.c
@@ -110,7 +110,8 @@ static inline void parse_http_header(char *header)
 HTTP_Client_State HttpClient_dowload(Http_client_info *info)
 {
     struct addrinfo *res;
-    unsigned int tot_http_pdu_rd, read_byte, full;
+    unsigned int tot_http_pdu_rd, full;
+    ssize_t read_byte;
     int err, sock;
     char *wrt_ptr;
 
@@ -207,6 +208,8 @@ HTTP_Client_State HttpClient_dowload(Http_client_info *info)
             full    = 0;
             vTaskDelayMs(50);
         }
+
+        //printf("Download size read data : %d\n", read_byte);
     } while (read_byte > 0);
 
     info->final_cb(info->buffer, full);


### PR DESCRIPTION
I was testing HTTP OTA and I realized that OTA locks down when Wifi connection drops. When this happens, POSIX function ```read``` (located at ```HttpClient_download```) returns -1. Since it's implemented as unsigned, ```do { ... } while(read_byte > 0)``` loops forever. Therefore the ```read_byte``` variable must be signed type. 