### PR TITLE
Improve wificfg

### DIFF
--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -1540,7 +1540,7 @@ static int handle_wificfg_challenge_post(int s, wificfg_method method,
     return wificfg_write_string(s, http_redirect_header);
 }
 
-#ifdef configUSE_TRACE_FACILITY
+#if configUSE_TRACE_FACILITY
 static const char *http_tasks_content[] = {
 #include "content/tasks.html"
 };
@@ -1638,7 +1638,7 @@ static const wificfg_dispatch wificfg_dispatch_list[] = {
     {"/challenge.html", HTTP_METHOD_POST, handle_wificfg_challenge_post, false},
     {"/wificfg/restart.html", HTTP_METHOD_POST, handle_restart_post, true},
     {"/wificfg/erase.html", HTTP_METHOD_POST, handle_erase_post, true},
-#ifdef configUSE_TRACE_FACILITY
+#if configUSE_TRACE_FACILITY
     {"/tasks", HTTP_METHOD_GET, handle_tasks, false},
     {"/tasks.html", HTTP_METHOD_GET, handle_tasks, false},
 #endif /* configUSE_TRACE_FACILITY */

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -58,7 +58,7 @@ const char *wificfg_default_ssid __attribute__ ((weak)) = "EOR_%02X%02X%02X";
 const char *wificfg_default_password __attribute__ ((weak)) = "esp-open-rtos";
 const char *wificfg_default_hostname __attribute__ ((weak)) = "eor-%02x%02x%02x";
 
-/* The http task stack allocates a single buffer to do much of it's work. */
+/* The http task stack allocates a single buffer to do much of its work. */
 #define HTTP_BUFFER_SIZE 54
 
 /*

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -54,9 +54,9 @@
 #endif
 
 
-const char *wificfg_default_ssid = "EOR_%02X%02X%02X";
-const char *wificfg_default_password = "esp-open-rtos";
-const char *wificfg_default_hostname = "eor-%02x%02x%02x";
+const char *wificfg_default_ssid __attribute__ ((weak)) = "EOR_%02X%02X%02X";
+const char *wificfg_default_password __attribute__ ((weak)) = "esp-open-rtos";
+const char *wificfg_default_hostname __attribute__ ((weak)) = "eor-%02x%02x%02x";
 
 /* The http task stack allocates a single buffer to do much of it's work. */
 #define HTTP_BUFFER_SIZE 54

--- a/extras/wificfg/wificfg.h
+++ b/extras/wificfg/wificfg.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
 /*
  * Printf format used to initialize a default AP ssid. It is passed the last
  * three bytes of the mac address. This may be NULL to not default the ssid,


### PR DESCRIPTION
Several small improvements of extras/wificfg:
* add missing #includes to wificfg.h
* use #if instead of #ifdef when checking for configUSE_TRACE_FACILITY
* make default ssid, password and hostname overridable by making the definitions in wificfg.c weak
* fix typo in comment
