### PR TITLE
Fix si7021 temperature/humidity sensor reading

### DIFF
--- a/extras/dht/dht.c
+++ b/extras/dht/dht.c
@@ -139,6 +139,9 @@ static inline int16_t dht_convert_data(dht_sensor_type_t sensor_type, uint8_t ms
             data = 0 - data;       // convert it to negative
         }
     }
+    else if (sensor_type == DHT_TYPE_SI7021) {
+        data = msb * 256 + (lsb & ~0x3);
+    }
     else {
         data = msb * 10;
     }


### PR DESCRIPTION
Raw reading modified according to the Silicon Labs sample code for the Si7021 sensor.

I've had issues trying to use the Si7021 sensor with Sonoff TH10 and TH16 devices, so looked into why it was always returning TEMP = 0, HUM = 2. The raw vales were not being interpreted as per the data sheet and Linux sample code that Silabs provide.