### PR TITLE
Fix full on/off in pca9685.

### DIFF
--- a/extras/pca9685/pca9685.c
+++ b/extras/pca9685/pca9685.c
@@ -185,6 +185,7 @@ void pca9685_set_pwm_value(i2c_dev_t *dev, uint8_t channel, uint16_t val)
     if (val == 0)
     {
         // Full off
+        // Takes precedence over full on.
         write_reg(dev, reg + OFFS_REG_LED_OFF, LED_FULL_ON_OFF);
     }
     else if (val < 4096)
@@ -195,6 +196,8 @@ void pca9685_set_pwm_value(i2c_dev_t *dev, uint8_t channel, uint16_t val)
     }
     else
     {
+        // Clear full off, as it takes precedence over full on.
+        write_reg(dev, reg + OFFS_REG_LED_OFF, 0);
         // Full on
         write_reg(dev, reg + OFFS_REG_LED_ON, LED_FULL_ON_OFF);
     }


### PR DESCRIPTION
It's currently not possible to toggle between full off and full on, as
switching to full on leaves the full off control bit set. The full off
control bit takes precedence according to the datasheet, which means the
signal remains off. (See [datasheet] page 21 for register definitions and
page 24 for information about precedence).

[datasheet]: https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf

The 'normal' branch does correctly clear full off/full on, as it writes
0s to the `LEDn_ON` registers unconditionally and writes 0 to the control
bit in `LEDn_OFF`.