### PR TITLE
Fix WiFi SSID long 32 gets wrongly truncated by one

### DIFF
--- a/core/include/sdk_internal.h
+++ b/core/include/sdk_internal.h
@@ -210,7 +210,7 @@ struct sdk_g_ic_volatile_st {
 
 struct sdk_g_ic_ssid_with_length {
     uint32_t ssid_length;  // 0x1e4 sdk_wpa_config_profile
-    uint8_t ssid[32];  // 0x1e8 Station ssid. Null terminated string.
+    uint8_t ssid[33];  // 0x1e8 Station ssid. Null terminated string.
 };
 
 // This is the portion of g_ic which is loaded/saved to the flash ROM, and thus

--- a/extras/wificfg/wificfg.c
+++ b/extras/wificfg/wificfg.c
@@ -2057,7 +2057,7 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
     sysparam_get_string("hostname", &hostname);
     if (!hostname && wificfg_default_hostname) {
         uint8_t macaddr[6];
-        char name[32];
+        char name[33];
         sdk_wifi_get_macaddr(1, macaddr);
         snprintf(name, sizeof(name), wificfg_default_hostname, macaddr[3],
                  macaddr[4], macaddr[5]);
@@ -2108,7 +2108,7 @@ void wificfg_init(uint32_t port, const wificfg_dispatch *dispatch)
         /* Default AP ssid and password. */
         if (!wifi_ap_ssid && wificfg_default_ssid) {
             uint8_t macaddr[6];
-            char ssid[32];
+            char ssid[33];
             sdk_wifi_get_macaddr(1, macaddr);
             snprintf(ssid, sizeof(ssid), wificfg_default_ssid, macaddr[3],
                      macaddr[4], macaddr[5]);

--- a/include/espressif/esp_softap.h
+++ b/include/espressif/esp_softap.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 struct sdk_softap_config {
-    uint8_t ssid[32];
+    uint8_t ssid[33];
     uint8_t password[64];
     uint8_t ssid_len;
     uint8_t channel;

--- a/include/espressif/esp_sta.h
+++ b/include/espressif/esp_sta.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 struct sdk_station_config {
-    uint8_t ssid[32];     /* Null terminated string */
+    uint8_t ssid[33];     /* Null terminated string */
     uint8_t password[64]; /* Null terminated string */
     uint8_t bssid_set;    /* One if bssid is used, otherwise zero. */
     uint8_t bssid[6];     /* The BSSID bytes */
@@ -38,7 +38,7 @@ struct sdk_bss_info {
     STAILQ_ENTRY(sdk_bss_info)     next;
 
     uint8_t bssid[6];
-    uint8_t ssid[32];
+    uint8_t ssid[33];
     uint8_t channel;
     int8_t rssi;
     AUTH_MODE authmode;


### PR DESCRIPTION
The maximum Wi-Fi SSID length is 32 characters, but if I try to connect to a network name which is exactly 32 characters long the last character gets truncated, eg: SSID: `533C Hyperoptic 1Gb Fibre 2.4Ghz` gets truncated to `533C Hyperoptic 1Gb Fibre 2.4Gh` since the SSID field in the structs of this project is defined as an array of size 32 but since it is a null terminated string, it should be defined as size 33...
Fix wifi SSID length to 33 since the maximum chars for SSID is 32 but the string is null terminated so array size must be 33.

I have noticed this wrong behaviour using the esp_haa and reported in their forum: https://github.com/RavenSystem/esp-homekit-devices/issues/1337 but it is not their fault...

Attached you can find my patch.